### PR TITLE
add spec for rise again

### DIFF
--- a/lib/magic/cards/rise_again.rb
+++ b/lib/magic/cards/rise_again.rb
@@ -1,7 +1,7 @@
 module Magic
   module Cards
     RiseAgain = Sorcery("Rise Again") do
-      cost black: 4, generic: 1
+      cost black: 1, generic: 4
     end
 
     class RiseAgain < Sorcery

--- a/spec/cards/containment_priest_spec.rb
+++ b/spec/cards/containment_priest_spec.rb
@@ -50,6 +50,17 @@ RSpec.describe Magic::Cards::ContainmentPriest do
         expect(game.battlefield.permanents.map(&:name)).to include('Story Seeker')
       end
     end
+
+    context "the creature returns from the graveyard via a sorcery" do
+      it "exiles the creature" do
+        p2.graveyard << Card('Story Seeker')
+        expect{
+          cast_and_resolve(card: Card("Rise Again"), player: p2, targeting: p2.graveyard.cards.first)
+        }.to change { game.exile.cards.count }.by(1)
+        expect(game.battlefield.permanents.count).to eq(1)
+        expect(game.battlefield.permanents.map(&:name)).to_not include('Story Seeker')
+      end
+    end
   end
 
   context "when a token creature enters the battlefield" do

--- a/spec/cards/containment_priest_spec.rb
+++ b/spec/cards/containment_priest_spec.rb
@@ -54,8 +54,13 @@ RSpec.describe Magic::Cards::ContainmentPriest do
     context "the creature returns from the graveyard via a sorcery" do
       it "exiles the creature" do
         p2.graveyard << Card('Story Seeker')
+        p2.add_mana(black: 5)
+        action = Magic::Actions::Cast.new(player: p2, card: Card("Rise Again"))
+        action.pay_mana(generic: { black: 4 }, black: 1)
+              .targeting(p2.graveyard.cards.first)
+        game.take_action(action)
         expect{
-          cast_and_resolve(card: Card("Rise Again"), player: p2, targeting: p2.graveyard.cards.first)
+          game.tick!
         }.to change { game.exile.cards.count }.by(1)
         expect(game.battlefield.permanents.count).to eq(1)
         expect(game.battlefield.permanents.map(&:name)).to_not include('Story Seeker')

--- a/spec/cards/containment_priest_spec.rb
+++ b/spec/cards/containment_priest_spec.rb
@@ -3,6 +3,7 @@ require "spec_helper"
 RSpec.describe Magic::Cards::ContainmentPriest do
   include_context "two player game"
 
+  let!(:wood_elves) { ResolvePermanent("Wood Elves", owner: p2) }
   subject! { ResolvePermanent("Containment Priest", owner: p1) }
   # Containment Priest {1}{U}{1}{W}
   # Creature -- Human Cleric
@@ -60,10 +61,10 @@ RSpec.describe Magic::Cards::ContainmentPriest do
               .targeting(p2.graveyard.cards.first)
         game.take_action(action)
 
-        p1.add_mana(red: 1)
-        action = Magic::Actions::Cast.new(player: p1, card: Card("Shock"))
+        p2.add_mana(red: 1)
+        action = Magic::Actions::Cast.new(player: p2, card: Card("Shock"))
         .pay_mana(red: 1)
-        .targeting(subject)
+        .targeting(wood_elves)
         game.take_action(action)
         expect{
           game.tick!

--- a/spec/cards/containment_priest_spec.rb
+++ b/spec/cards/containment_priest_spec.rb
@@ -59,6 +59,12 @@ RSpec.describe Magic::Cards::ContainmentPriest do
         action.pay_mana(generic: { black: 4 }, black: 1)
               .targeting(p2.graveyard.cards.first)
         game.take_action(action)
+
+        p1.add_mana(red: 1)
+        action = Magic::Actions::Cast.new(player: p1, card: Card("Shock"))
+        .pay_mana(red: 1)
+        .targeting(subject)
+        game.take_action(action)
         expect{
           game.tick!
         }.to change { game.exile.cards.count }.by(1)


### PR DESCRIPTION
Hey,
So, as per our conversation in #497 , this is the added spec. I wasn't sure whether you it was necessary to cast the shock instant to send the creature to the graveyard, though I think either way the last action would still be rise again, so it wouldn't hit the second guard clause. I believe, effectively, this means that the containment priest's current implementation still functions as expected.

Let me know if I misunderstood or you'd like me to update the spec? Thanks!