### PR TITLE
after ActivateAbility on a Land, check if it's tapped too

### DIFF
--- a/spec/game/integration/turns_spec.rb
+++ b/spec/game/integration/turns_spec.rb
@@ -41,6 +41,7 @@ RSpec.describe Magic::Game::Turn, "turn walkthrough" do
     action = Magic::Actions::ActivateAbility.new(player: p1, permanent: island, ability: island.activated_abilities.first)
     game.take_action(action)
     expect(p1.mana_pool).to eq(blue: 1)
+    expect(island).to be_tapped
 
     island2 = p1.hand.by_name("Island").first
     action = Magic::Actions::PlayLand.new(player: p1, card: island2)


### PR DESCRIPTION
amazing, exceedingly cool gem; especially how much of the actual rules and game logic you've implemented.

I have a silly idea that "borrows" a number of ideas from "Magic: The Gathering" so I went hunting for an engine to experiment inside and this one by far seems the most complete on Github, as well as being well-organized. (I'm also a Ruby lover, so that helps.)

in order to implement my silly idea, I've started by experimenting in a fairly unstructured way to see what parts of the engine are fully wired up. finding `turns_spec` was really useful because I was trying to `Actions::Tap` a land instead of `ActivateAbility` it. (`turns_spec` also teaches one how to use the Ruby state-machine; I basically guessed the method names before finding the example code ...)

however, despite [having a defined `Costs`](https://github.com/radar/mtg/blob/61f97f66a2d18600b744c8ec947593caa25c9d3a/lib/magic/cards/island.rb#L9) and also [code indicating the ability to `pay()` a `Costs::Tap`](https://github.com/radar/mtg/blob/61f97f66a2d18600b744c8ec947593caa25c9d3a/lib/magic/actions/activate_ability.rb#L66), the minimal test-case of `expect(island).to be_tapped` actually fails 😿  (we do correctly get Mana added to our `mana_pool` tho!)

this might actually be a known issue, I wanted to check in and make sure I'm not doing something obviously incorrect before I dig deeper and attempt to fix/implement it. I also have an interest in `Counters` related features and some initial experiments have failed to apply counters to a card as it `enters-the-battlefield`... again, I might be doing something wrong or `Counters` might not be finished.
