### PR TITLE
Making actions instance methods on Player for cleaner Ruby syntax

### DIFF
--- a/lib/magic/action.rb
+++ b/lib/magic/action.rb
@@ -1,10 +1,10 @@
 module Magic
   class Action
-    attr_reader :player, :game
+    attr_reader :game, :player
 
-    def initialize(player:)
+    def initialize(game:, player:)
+      @game = game
       @player = player
-      @game = player.game
     end
   end
 end

--- a/lib/magic/actions/activate_ability.rb
+++ b/lib/magic/actions/activate_ability.rb
@@ -1,11 +1,10 @@
 module Magic
   module Actions
     class ActivateAbility < Action
-      attr_reader :permanent, :ability, :costs, :requirements, :targets
+      attr_reader :ability, :costs, :requirements, :targets
 
-      def initialize(permanent:, ability:, **args)
-        @permanent = permanent
-        @ability = ability.new(source: permanent)
+      def initialize(ability:, **args)
+        @ability = ability
         @costs = @ability.costs
         @requirements = @ability.requirements
         @targets = []
@@ -13,7 +12,7 @@ module Magic
       end
 
       def inspect
-        "#<Actions::Actions::ActivateAbility permanent: #{permanent.name}, ability: #{ability.class}>"
+        "#<Actions::Actions::ActivateAbility source: #{ability.source.name}, ability: #{ability.class}>"
       end
 
       def can_be_activated?(player)
@@ -51,6 +50,10 @@ module Magic
         pay(player, :multi_tap, targets)
       end
 
+      def pay_sacrifice(targets)
+        pay(player, :sacrifice, targets)
+      end
+
       def perform
         if targets.any?
           if ability.single_target?
@@ -83,6 +86,10 @@ module Magic
         cost.pay(player, payment)
 
         self
+      end
+
+      def has_cost?(cost_type)
+        costs.any? { |cost| cost.is_a?(cost_type) }
       end
 
       def finalize_costs!(player)

--- a/lib/magic/actions/activate_ability.rb
+++ b/lib/magic/actions/activate_ability.rb
@@ -38,20 +38,20 @@ module Magic
       end
 
       def pay_mana(payment)
-        pay(player, :mana, payment)
+        pay(:mana, payment)
         self
       end
 
       def pay_tap
-        pay(player, :tap)
+        pay(:tap)
       end
 
       def pay_multi_tap(targets)
-        pay(player, :multi_tap, targets)
+        pay(:multi_tap, targets)
       end
 
       def pay_sacrifice(targets)
-        pay(player, :sacrifice, targets)
+        pay(:sacrifice, targets)
       end
 
       def perform
@@ -66,7 +66,7 @@ module Magic
         end
       end
 
-      def pay(player, cost_type, payment = nil)
+      def pay(cost_type, payment = nil)
         cost_type = case cost_type
         when :mana
           Costs::Mana

--- a/lib/magic/actions/activate_loyalty_ability.rb
+++ b/lib/magic/actions/activate_loyalty_ability.rb
@@ -3,9 +3,9 @@ module Magic
     class ActivateLoyaltyAbility < Action
       attr_reader :ability, :planeswalker, :targets, :x_value
 
-      def initialize(planeswalker:, ability:, **args)
-        @planeswalker = planeswalker
-        @ability = ability.new(planeswalker: planeswalker)
+      def initialize(ability:, **args)
+        @planeswalker = ability.planeswalker
+        @ability = ability
         @targets = []
         super(**args)
       end

--- a/lib/magic/actions/cast.rb
+++ b/lib/magic/actions/cast.rb
@@ -3,6 +3,8 @@ module Magic
     class Cast < Action
       extend Forwardable
 
+      class InvalidTarget < StandardError; end
+
       def_delegators :@card, :enchantment?, :artifact?
       attr_reader :card, :targets
       def initialize(card:, **args)
@@ -47,6 +49,10 @@ module Magic
         end
       end
 
+      def auto_pay
+        mana_cost.auto_pay(player)
+      end
+
       def kicker_cost
         card.kicker_cost
       end
@@ -69,7 +75,7 @@ module Magic
 
       def targeting(*targets)
         targets.each do |target|
-          raise "Invalid target for #{card.name}: #{target}" unless can_target?(target)
+          raise InvalidTarget, "Invalid target for #{card.name}: #{target}" unless can_target?(target)
         end
         @targets = targets
         self

--- a/lib/magic/actions/play_land.rb
+++ b/lib/magic/actions/play_land.rb
@@ -13,8 +13,7 @@ module Magic
       end
 
       def can_perform?
-        return false if player.can_play_lands?
-        true
+        player.can_play_lands?
       end
 
       def perform

--- a/lib/magic/cards/animal_sanctuary.rb
+++ b/lib/magic/cards/animal_sanctuary.rb
@@ -12,14 +12,14 @@ module Magic
         end
 
         def resolve!
-          controller.add_mana(colorless: 1)
+          controller.add_mana(generic: 1)
         end
       end
 
       class ActivatedAbility < Magic::ActivatedAbility
         def costs
           [
-            Costs::Mana.new(colorless: 2),
+            Costs::Mana.new(generic: 2),
             Costs::Tap.new(source),
           ]
         end

--- a/lib/magic/cards/celestial_enforcer.rb
+++ b/lib/magic/cards/celestial_enforcer.rb
@@ -36,6 +36,8 @@ module Magic
           target.tap!
         end
       end
+
+      def activated_abilities = [ActivatedAbility]
     end
   end
 end

--- a/lib/magic/cards/fabled_passage.rb
+++ b/lib/magic/cards/fabled_passage.rb
@@ -2,7 +2,6 @@ module Magic
   module Cards
     class FabledPassage < Land
       NAME = "Fabled Passage"
-      TYPE_LINE = "Land"
 
       def target_choices(receiver)
         receiver.controller.library.basic_lands
@@ -30,9 +29,7 @@ module Magic
         end
       end
 
-      def activated_abilities
-        [ActivatedAbility]
-      end
+      def activated_abilities = [ActivatedAbility]
     end
   end
 end

--- a/lib/magic/cards/faiths_fetters.rb
+++ b/lib/magic/cards/faiths_fetters.rb
@@ -23,7 +23,7 @@ module Magic
       end
 
       def can_activate_ability?(ability)
-        ability < ManaAbility
+        ability.is_a?(ManaAbility)
       end
     end
   end

--- a/lib/magic/cards/idol_of_endurance.rb
+++ b/lib/magic/cards/idol_of_endurance.rb
@@ -40,9 +40,9 @@ module Magic
 
         def resolve!(target:)
           source.remove_from_exile(target)
-          cast_action = Magic::Actions::Cast.new(card: target, player: source.controller)
-          cast_action.mana_cost = 0
-          game.take_action(cast_action)
+          source.controller.cast(card: target) do
+            _1.mana_cost = 0
+          end
         end
       end
 

--- a/lib/magic/cards/land.rb
+++ b/lib/magic/cards/land.rb
@@ -1,6 +1,8 @@
 module Magic
   module Cards
     class Land < Card
+      type "Land"
+
       def play!
         move_zone!(game.battlefield)
       end

--- a/lib/magic/cards/shock.rb
+++ b/lib/magic/cards/shock.rb
@@ -12,10 +12,8 @@ module Magic
       end
 
       def resolve!(_controller, target:)
-          game.add_effect(Effects::DealDamage.new(source: self, targets: [target], damage: 2)) 
+        game.add_effect(Effects::DealDamage.new(source: self, targets: [target], damage: 2))
       end
     end
-    
-      
   end
 end

--- a/lib/magic/costs/mana.rb
+++ b/lib/magic/costs/mana.rb
@@ -54,11 +54,17 @@ module Magic
       end
 
       def pay(player, payment)
-
         raise CannotPay unless can_pay?(player)
 
         pay_generic(payment[:generic]) if payment[:generic]
         pay_colors(payment.slice(*Magic::Mana::COLORS))
+      end
+
+      def auto_pay(player)
+        raise CannotPay unless can_pay?(player)
+
+        pay_colors(color_costs)
+        pay_generic(generic: cost[:generic]) if cost[:generic]
       end
 
       def finalize!(player)

--- a/lib/magic/effects/single_target.rb
+++ b/lib/magic/effects/single_target.rb
@@ -1,0 +1,27 @@
+module Magic
+  module Effects
+    class SingleTarget < Effect
+      class InvalidTarget < StandardError; end;
+
+      attr_reader :source, :target, :choices
+
+      def initialize(source:, target:, choices: source.target_choices)
+        @target = target
+        @source = source
+        @choices = [*choices]
+      end
+
+      def requires_choices?
+        true
+      end
+
+      def single_choice?
+        choices.count == 1
+      end
+
+      def no_choice?
+        choices.count.zero?
+      end
+    end
+  end
+end

--- a/lib/magic/effects/targeted_effect.rb
+++ b/lib/magic/effects/targeted_effect.rb
@@ -21,10 +21,6 @@ module Magic
         end
       end
 
-      def requires_targets?
-        true
-      end
-
       def requires_choices?
         true
       end

--- a/lib/magic/game.rb
+++ b/lib/magic/game.rb
@@ -40,7 +40,7 @@ module Magic
     def add_players(*players)
       players.each(&method(:add_player))
     end
-
+\
     def add_player(player)
       @player_count += 1
       @players << player

--- a/lib/magic/permanent.rb
+++ b/lib/magic/permanent.rb
@@ -4,7 +4,7 @@ module Magic
     include Types
 
     extend Forwardable
-    attr_reader :game, :owner, :controller, :card,:types, :delayed_responses, :attachments, :protections, :modifiers, :counters, :keywords, :keyword_grants, :activated_abilities, :exiled_cards, :cannot_untap_next_turn
+    attr_reader :game, :owner, :controller, :card, :types, :delayed_responses, :attachments, :protections, :modifiers, :counters, :keywords, :keyword_grants, :activated_abilities, :exiled_cards, :cannot_untap_next_turn
 
     def_delegators :@card, :name, :cmc, :mana_value, :colors, :colorless?
     def_delegators :@game, :logger
@@ -49,7 +49,6 @@ module Magic
       @keywords = card.keywords
       @keyword_grants = []
       @counters = Counters::Collection.new([])
-      @activated_abilities = card.activated_abilities
       @damage = 0
       @protections = Protections.new(card.protections.dup)
       @exiled_cards = Magic::CardList.new([])
@@ -65,6 +64,10 @@ module Magic
 
     def inspect
       "#<Magic::Permanent name:#{card.name} controller:#{controller.name}>"
+    end
+
+    def activated_abilities
+      @activated_abilities ||= card.activated_abilities.map { |ability| ability.new(source: self) }
     end
 
     alias_method :to_s, :inspect

--- a/lib/magic/permanents/planeswalker.rb
+++ b/lib/magic/permanents/planeswalker.rb
@@ -12,7 +12,7 @@ module Magic
         @loyalty += change
         destroy! if loyalty <= 0
       end
-      
+
       def take_damage(source:, damage:)
         game.notify!(
           Events::DamageDealt.new(
@@ -24,9 +24,8 @@ module Magic
         change_loyalty!(- damage)
       end
 
-
       def loyalty_abilities
-        card.loyalty_abilities
+        card.loyalty_abilities.map { |ability| ability.new(planeswalker: self) }
       end
     end
   end

--- a/lib/magic/player.rb
+++ b/lib/magic/player.rb
@@ -54,10 +54,15 @@ module Magic
       game.take_action(action)
     end
 
-    def activate_ability(ability:, auto_tap: true, **args)
+    def prepare_activate_ability(ability:, **args, &block)
       action = prepare_action(Magic::Actions::ActivateAbility, ability: ability, **args)
-      action.pay_tap if action.has_cost?(Magic::Costs::Tap) && auto_tap
       yield action if block_given?
+      action
+    end
+
+    def activate_ability(ability:, auto_tap: true, **args, &block)
+      action = prepare_activate_ability(ability: ability, **args, &block)
+      action.pay_tap if action.has_cost?(Magic::Costs::Tap) && auto_tap
       action.finalize_costs!(self)
       game.take_action(action)
     end
@@ -68,12 +73,24 @@ module Magic
       game.take_action(action)
     end
 
-    def cast(card:, **args)
+    def prepare_cast(card:, **args)
       action = prepare_action(Magic::Actions::Cast, card: card, **args)
       yield action if block_given?
+      action
+    end
+
+    def cast(card:, **args, &block)
+      action = prepare_cast(card: card, **args, &block)
       game.take_action(action)
       action
     end
+
+    def declare_attacker(attacker:, target:, **args)
+      action = prepare_action(Magic::Actions::DeclareAttacker, attacker: attacker, target: target, **args)
+      game.take_action(action)
+      action
+    end
+
 
 
     def lost?

--- a/lib/magic/stack.rb
+++ b/lib/magic/stack.rb
@@ -131,6 +131,7 @@ module Magic
     def resolve_effects!
       resolvable_effects_with_targets = effects.unresolved.targeted
       resolvable_effects_with_targets.each do |effect|
+        effects.delete(effect)
         effect.targets.each do |target|
           effect.resolve(target)
         end

--- a/spec/cards/academy_elite_spec.rb
+++ b/spec/cards/academy_elite_spec.rb
@@ -17,9 +17,9 @@ RSpec.describe Magic::Cards::AcademyElite do
     context "when it enters the battlefield" do
       it "gets 1 +1/+1 counter" do
         p1.add_mana(blue: 4)
-        action = Magic::Actions::Cast.new(player: p1, card: academy_elite)
-        action.pay_mana(generic: { blue: 3 }, blue: 1)
-        game.take_action(action)
+        p1.cast(card: academy_elite) do
+          _1.pay_mana(generic: { blue: 3 }, blue: 1)
+        end
         game.tick!
 
         permanent = p1.permanents.last
@@ -39,9 +39,9 @@ RSpec.describe Magic::Cards::AcademyElite do
     context "when it enters the battlefield" do
       it "gets 2 +1/+1 counters" do
         p1.add_mana(blue: 4)
-        action = Magic::Actions::Cast.new(player: p1, card: academy_elite)
-        action.pay_mana(generic: { blue: 3 }, blue: 1)
-        game.take_action(action)
+        p1.cast(card: academy_elite) do
+          _1.pay_mana(generic: { blue: 3 }, blue: 1)
+        end
         game.tick!
 
         permanent = p1.permanents.last

--- a/spec/cards/altars_light_spec.rb
+++ b/spec/cards/altars_light_spec.rb
@@ -12,10 +12,10 @@ RSpec.describe Magic::Cards::AltarsLight do
   end
 
   it "exiles the sol ring" do
-    action = cast_action(card: card, player: p1)
-    action.targeting(sol_ring)
-    add_to_stack_and_resolve(action)
-
+    p1.add_mana(white: 4)
+    cast_and_resolve(card: card, player: p1) do
+      _1.targeting(sol_ring)
+    end
     expect(sol_ring.card.zone).to be_exile
   end
 end

--- a/spec/cards/angelic_ascension_spec.rb
+++ b/spec/cards/angelic_ascension_spec.rb
@@ -7,8 +7,9 @@ RSpec.describe Magic::Cards::AngelicAscension do
   subject { add_to_library("Angelic Ascension", player: p1) }
 
   it "exiles the wood elves and creates a 4/4 white angel creature token with flying" do
-    action = cast_action(card: subject, player: p1, targeting: wood_elves)
-    add_to_stack_and_resolve(action)
+    action = cast_and_resolve(card: subject, player: p1) do |action|
+      action.targeting(wood_elves)
+    end
 
     expect(wood_elves.card.zone).to be_exile
     expect(wood_elves.zone).to be_nil

--- a/spec/cards/animal_sanctuary_spec.rb
+++ b/spec/cards/animal_sanctuary_spec.rb
@@ -8,13 +8,12 @@ RSpec.describe Magic::Cards::AnimalSanctuary do
 
   context "mana ability" do
     def activate_ability
-      action = Magic::Actions::ActivateAbility.new(permanent: subject, ability: subject.activated_abilities.first, player: p1)
-      game.take_action(action)
+      p1.activate_ability(ability: subject.activated_abilities.first)
     end
 
     it "adds one colorless mana" do
       activate_ability
-      expect(p1.mana_pool[:colorless]).to eq(1)
+      expect(p1.mana_pool[:generic]).to eq(1)
     end
   end
 
@@ -26,9 +25,9 @@ RSpec.describe Magic::Cards::AnimalSanctuary do
 
     def activate_ability
       p1.add_mana(green: 2)
-      action = Magic::Actions::ActivateAbility.new(permanent: subject, ability: subject.activated_abilities.last, player: p1)
-      action.pay_mana(colorless: { green: 2 })
-      game.take_action(action)
+      p1.activate_ability(ability: subject.activated_abilities.last) do
+        _1.pay_mana(generic: { green: 2 })
+      end
       game.stack.resolve!
     end
 

--- a/spec/cards/anointed_chorister_spec.rb
+++ b/spec/cards/anointed_chorister_spec.rb
@@ -14,10 +14,10 @@ RSpec.describe Magic::Cards::AnointedChorister do
     it "applies a buff of +3/+3" do
       p1.add_mana(white: 5)
 
-      action = Magic::Actions::ActivateAbility.new(player: p1, permanent: permanent, ability: permanent.activated_abilities.first)
-      action.pay_mana({ generic: { white: 4 }, white: 1 })
-      action.finalize_costs!(p1)
-      game.take_action(action)
+      p1.activate_ability(ability: permanent.activated_abilities.first) do
+        _1.pay_mana({ generic: { white: 4 }, white: 1 })
+      end
+
       game.tick!
 
       expect(p1.mana_pool[:white]).to eq(0)

--- a/spec/cards/aron_benalias_ruin_spec.rb
+++ b/spec/cards/aron_benalias_ruin_spec.rb
@@ -15,10 +15,11 @@ RSpec.describe Magic::Cards::AronBenaliasRuin do
     it "puts a +1/+1 counter on all creatures under p1's control" do
       expect(subject.activated_abilities.count).to eq(1)
       p1.add_mana(white: 1, black: 1)
-      action = Magic::Actions::ActivateAbility.new(permanent: subject, ability: subject.activated_abilities.first, player: p1)
-      action.pay_mana(white: 1, black: 1)
-      action.pay(p1, :sacrifice, wood_elves)
-      game.take_action(action)
+
+      p1.activate_ability(ability: subject.activated_abilities.first) do
+        _1.pay_mana(white: 1, black: 1)
+        _1.pay_sacrifice(wood_elves)
+      end
       game.stack.resolve!
 
       aggregate_failures do

--- a/spec/cards/basri_ket_spec.rb
+++ b/spec/cards/basri_ket_spec.rb
@@ -16,9 +16,9 @@ RSpec.describe Magic::Cards::BasriKet do
     end
 
     it "targets the wood elves" do
-      action = Magic::Actions::ActivateLoyaltyAbility.new(player: p1, planeswalker: planeswalker, ability: ability)
-      action.targeting(wood_elves)
-      game.take_action(action)
+      p1.activate_loyalty_ability(ability: ability) do
+        _1.targeting(wood_elves)
+      end
       game.tick!
 
       expect(planeswalker.loyalty).to eq(4)
@@ -37,8 +37,7 @@ RSpec.describe Magic::Cards::BasriKet do
     end
 
     it "adds an after attackers declared step trigger" do
-      action = Magic::Actions::ActivateLoyaltyAbility.new(player: p1, planeswalker: planeswalker, ability: ability)
-      game.take_action(action)
+      p1.activate_loyalty_ability(ability: ability)
       game.tick!
 
       expect(subject.loyalty).to eq(1)
@@ -51,8 +50,7 @@ RSpec.describe Magic::Cards::BasriKet do
     let(:ability) { planeswalker.loyalty_abilities[2] }
 
     it "emblem for creating white soldier creature tokens and putting counters on all creatures" do
-      action = Magic::Actions::ActivateLoyaltyAbility.new(player: p1, planeswalker: planeswalker, ability: ability)
-      game.take_action(action)
+      p1.activate_loyalty_ability(ability: ability)
       game.tick!
 
       expect(game.emblems.count).to eq(1)

--- a/spec/cards/burn_bright_spec.rb
+++ b/spec/cards/burn_bright_spec.rb
@@ -12,9 +12,10 @@ RSpec.describe Magic::Cards::BurnBright do
 
     it "grants 2 power to both creatures " do
       p1.add_mana(red: 3)
-      action = Magic::Actions::Cast.new(player: p1, card: burn_bright)
-        .pay_mana(generic: { red: 2 }, red: 1)
-      game.take_action(action)
+      p1.cast(card: burn_bright) do
+        _1.pay_mana(red: 1, generic: { red: 2 })
+      end
+
       game.tick!
 
       expect(onakke_ogre.power).to eq(6)
@@ -22,12 +23,21 @@ RSpec.describe Magic::Cards::BurnBright do
       expect(blood_glutton.power).to eq(6)
       expect(blood_glutton.toughness).to eq(3)
 
-      game.current_turn.end!
-      game.current_turn.cleanup!
-      game.next_turn
+      expect(onakke_ogre.modifiers).to include(
+        an_object_having_attributes(
+          power: 2,
+          toughness: 0,
+          until_eot: true,
+        )
+      )
 
-      expect(onakke_ogre.power).to eq(4)
-      expect(blood_glutton.power).to eq(4)
+      expect(blood_glutton.modifiers).to include(
+        an_object_having_attributes(
+          power: 2,
+          toughness: 0,
+          until_eot: true,
+        )
+      )
     end
   end
 
@@ -36,11 +46,11 @@ RSpec.describe Magic::Cards::BurnBright do
     let!(:onakke_ogre) { ResolvePermanent("Onakke Ogre", owner: p1) }
     let!(:cloudkin_seer) { ResolvePermanent("Cloudkin Seer", owner: p2) }
 
-    it "does not buff opponent's creature " do
+    it "does not buff opponent's creature" do
       p1.add_mana(red: 3)
-      action = Magic::Actions::Cast.new(player: p1, card: burn_bright)
-        .pay_mana(generic: { red: 2 }, red: 1)
-      game.take_action(action)
+      p1.cast(card: burn_bright) do
+        _1.pay_mana(red: 1, generic: { red: 2 })
+      end
       game.tick!
 
       expect(cloudkin_seer.power).to eq(2)

--- a/spec/cards/cancel_spec.rb
+++ b/spec/cards/cancel_spec.rb
@@ -14,15 +14,15 @@ RSpec.describe Magic::Cards::Cancel do
   context "counters a Sol Ring" do
     it "sol ring never enters the battlefield" do
       p2.add_mana(red: 1)
-      action = Magic::Actions::Cast.new(player: p2, card: sol_ring)
-      action.pay_mana(generic: { red: 1 })
-      game.take_action(action)
+      action = p2.cast(card: sol_ring) do
+        _1.pay_mana(generic: { red: 1 })
+      end
 
       p1.add_mana(blue: 3)
-      action_2 = Magic::Actions::Cast.new(player: p1, card: cancel)
-      action_2.targeting(action)
-      action_2.pay_mana(blue: 2, generic: { blue: 1 })
-      game.take_action(action_2)
+      action_2 = p1.cast(card: cancel) do
+        _1.pay_mana(blue: 2, generic: { blue: 1 })
+        _1.targeting(action)
+      end
 
       game.stack.resolve!
       expect(cancel.zone).to be_graveyard

--- a/spec/cards/celestial_enforcer_spec.rb
+++ b/spec/cards/celestial_enforcer_spec.rb
@@ -8,7 +8,7 @@ RSpec.describe Magic::Cards::CelestialEnforcer do
 
   context "activated ability" do
     def ability
-      permanent.card.class::ActivatedAbility
+      permanent.activated_abilities.first
     end
 
     context "when p1 has two white mana" do
@@ -24,11 +24,12 @@ RSpec.describe Magic::Cards::CelestialEnforcer do
 
           it "taps a target creature" do
             p1.add_mana(white: 2)
-            action = Magic::Actions::ActivateAbility.new(player: p1, permanent: permanent, ability: ability)
-            action.pay_mana(generic: { white: 1 }, white: 1)
-            action.pay_tap
-            action.targeting(wood_elves)
-            game.take_action(action)
+            p1.activate_ability(ability: ability) do
+              _1
+                .targeting(wood_elves)
+                .pay_mana(generic: { white: 1 }, white: 1)
+                .pay_tap
+            end
             game.stack.resolve!
             expect(permanent).to be_tapped
             expect(wood_elves).to be_tapped
@@ -37,7 +38,7 @@ RSpec.describe Magic::Cards::CelestialEnforcer do
 
         context "when p1 does not control any creatures with flying" do
           it "cannot be activated" do
-            action = Magic::Actions::ActivateAbility.new(player: p1, permanent: permanent, ability: ability)
+            action = p1.prepare_activate_ability(ability: ability)
             expect(action.can_be_activated?(p1)).to eq(false)
           end
         end
@@ -47,7 +48,7 @@ RSpec.describe Magic::Cards::CelestialEnforcer do
         before { permanent.tap! }
 
         it "cannot be activated" do
-          action = Magic::Actions::ActivateAbility.new(player: p1, permanent: permanent, ability: ability)
+          action = p1.prepare_activate_ability(ability: ability)
           expect(action.can_be_activated?(p1)).to eq(false)
         end
       end

--- a/spec/cards/containment_priest_spec.rb
+++ b/spec/cards/containment_priest_spec.rb
@@ -42,9 +42,9 @@ RSpec.describe Magic::Cards::ContainmentPriest do
         story_seeker.zone = p2.hand
 
         p2.add_mana(white: 2)
-        action = Magic::Actions::Cast.new(player: p2, card: story_seeker)
-        action.pay_mana(generic: { white: 1 }, white: 1)
-        game.take_action(action)
+        p2.cast(card: story_seeker) do
+          _1.pay_mana(generic: { white: 1 }, white: 1)
+        end
         game.tick!
 
         expect(game.battlefield.permanents.count).to eq(3)
@@ -56,16 +56,19 @@ RSpec.describe Magic::Cards::ContainmentPriest do
       it "exiles the creature" do
         p2.graveyard << Card('Story Seeker')
         p2.add_mana(black: 5)
-        action = Magic::Actions::Cast.new(player: p2, card: Card("Rise Again"))
-        action.pay_mana(generic: { black: 4 }, black: 1)
-              .targeting(p2.graveyard.cards.first)
-        game.take_action(action)
+        p2.cast(card: Card("Rise Again")) do
+          _1
+            .pay_mana(generic: { black: 4 }, black: 1)
+            .targeting(p2.graveyard.cards.first)
+        end
 
         p2.add_mana(red: 1)
-        action = Magic::Actions::Cast.new(player: p2, card: Card("Shock"))
-        .pay_mana(red: 1)
-        .targeting(wood_elves)
-        game.take_action(action)
+        p2.cast(card: Card("Shock")) do
+          _1
+            .pay_mana(red: 1)
+            .targeting(wood_elves)
+        end
+
         expect{
           game.tick!
         }.to change { game.exile.cards.count }.by(1)

--- a/spec/cards/fabled_passage_spec.rb
+++ b/spec/cards/fabled_passage_spec.rb
@@ -10,9 +10,9 @@ RSpec.describe Magic::Cards::FabledPassage do
   end
 
   def activate_ability
-    action = Magic::Actions::ActivateAbility.new(permanent: subject, ability: subject.activated_abilities.first, player: p1)
-    action.pay(p1, :sacrifice)
-    game.take_action(action)
+    p1.activate_ability(ability: subject.activated_abilities.first) do
+      _1.pay(:sacrifice)
+    end
     game.stack.resolve!
     effect = game.effects.first
     expect(effect).to be_a(Magic::Cards::FabledPassage::Effect)

--- a/spec/cards/font_of_fertility_spec.rb
+++ b/spec/cards/font_of_fertility_spec.rb
@@ -13,10 +13,12 @@ RSpec.describe Magic::Cards::FontOfFertility do
     it "searches for a basic land, puts it on the battlefield tapped" do
       expect(subject.activated_abilities.count).to eq(1)
       p1.add_mana(green: 2)
-      action = Magic::Actions::ActivateAbility.new(permanent: subject, ability: subject.activated_abilities.first, player: p1)
-      action.pay_mana(green: 1)
-      action.pay(p1, :sacrifice)
-      game.take_action(action)
+      p1.activate_ability(ability: subject.activated_abilities.first) do
+        _1
+          .pay_mana(green: 1)
+          .pay(:sacrifice)
+      end
+
       game.stack.resolve!
       effect = game.effects.first
       expect(effect).to be_a(Magic::Effects::SearchLibraryForBasicLand)

--- a/spec/cards/goblin_wizardry_spec.rb
+++ b/spec/cards/goblin_wizardry_spec.rb
@@ -8,9 +8,9 @@ RSpec.describe Magic::Cards::GoblinWizardry do
   context "casting Goblin Wizardry" do
     before do
       p1.add_mana(red: 4)
-      action = Magic::Actions::Cast.new(player: p1, card: goblin_wizardry)
-        .pay_mana(generic: { red: 3 }, red: 1)
-      game.take_action(action)
+      p1.cast(card: goblin_wizardry) do
+        _1.pay_mana(generic: { red: 3 }, red: 1)
+      end
       game.tick!
     end
 

--- a/spec/cards/golgari_guildgate_spec.rb
+++ b/spec/cards/golgari_guildgate_spec.rb
@@ -6,8 +6,7 @@ RSpec.describe Magic::Cards::GolgariGuildgate do
   let(:card) { described_class.new(game: game) }
 
   let!(:permanent) do
-    action = Magic::Actions::PlayLand.new(player: p1, card: card)
-    game.take_action(action)
+    p1.play_land(land: card)
     p1.permanents.by_name("Golgari Guildgate").first
   end
 
@@ -17,9 +16,9 @@ RSpec.describe Magic::Cards::GolgariGuildgate do
   end
 
   it "taps for either black or green" do
-    action = Magic::Actions::ActivateAbility.new(player: p1, permanent: permanent, ability: card.activated_abilities.first)
-    action.pay_tap
-    game.take_action(action)
+    p1.activate_ability(ability: permanent.activated_abilities.first) do
+      _1.pay_tap
+    end
     game.resolve_pending_effect(black: 1)
     expect(game.effects).to be_empty
     expect(p1.mana_pool[:black]).to eq(1)

--- a/spec/cards/great_furnace_spec.rb
+++ b/spec/cards/great_furnace_spec.rb
@@ -7,9 +7,8 @@ RSpec.describe Magic::Cards::GreatFurnace do
 
   it "taps for red mana" do
     expect(p1).to receive(:add_mana).with(red: 1)
-    action = Magic::Actions::ActivateAbility.new(player: p1, permanent: subject, ability: subject.activated_abilities.first)
-    action.pay_tap
-    game.take_action(action)
+
+    p1.activate_ability(ability: subject.activated_abilities.first)
     expect(subject).to be_tapped
   end
 

--- a/spec/cards/hellkite_punisher_spec.rb
+++ b/spec/cards/hellkite_punisher_spec.rb
@@ -14,15 +14,15 @@ RSpec.describe Magic::Cards::HellkitePunisher do
       p1.add_mana(red: 2)
 
       ability = subject.activated_abilities.first
-      action = Magic::Actions::ActivateAbility.new(player: p1, permanent: subject, ability: ability)
-      action.pay_mana(red: 1)
-      game.take_action(action)
+      p1.activate_ability(ability: ability) do
+        _1.pay_mana(red: 1)
+      end
       game.stack.resolve!
       expect(subject.power).to eq(7)
 
-      action = Magic::Actions::ActivateAbility.new(player: p1, permanent: subject, ability: ability)
-      action.pay_mana(red: 1)
-      game.take_action(action)
+      p1.activate_ability(ability: ability) do
+        _1.pay_mana(red: 1)
+      end
       game.stack.resolve!
 
       expect(subject.power).to eq(8)

--- a/spec/cards/idol_of_endurance_spec.rb
+++ b/spec/cards/idol_of_endurance_spec.rb
@@ -26,14 +26,12 @@ RSpec.describe Magic::Cards::IdolOfEndurance do
     end
 
     it "can play that card without incurring mana cost" do
-
       p1.add_mana(white: 2)
-      action = Magic::Actions::ActivateAbility.new(player: p1, permanent: idol_of_endurance, ability: idol_of_endurance.activated_abilities.first)
-      action.pay_mana({ generic: { white: 1 }, white: 1 })
-      action.pay_tap
-      action.finalize_costs!(p1)
-      action.targeting(wood_elves)
-      game.take_action(action)
+      p1.activate_ability(ability: idol_of_endurance.activated_abilities.first) do
+        _1
+          .targeting(wood_elves)
+          .pay_mana(generic: { white: 1 }, white: 1)
+      end
       game.tick!
 
       expect(idol_of_endurance).to be_tapped

--- a/spec/cards/island_spec.rb
+++ b/spec/cards/island_spec.rb
@@ -7,8 +7,7 @@ RSpec.describe Magic::Cards::Island do
 
   it "taps for a single blue mana" do
     expect(p1).to receive(:add_mana).with(blue: 1)
-    action = Magic::Actions::ActivateAbility.new(player: p1, permanent: subject, ability: subject.activated_abilities.first)
-    action.pay_tap
-    game.take_action(action)
+    p1.activate_ability(ability: subject.activated_abilities.first)
+    expect(subject).to be_tapped
   end
 end

--- a/spec/cards/jungle_hollow_spec.rb
+++ b/spec/cards/jungle_hollow_spec.rb
@@ -6,8 +6,7 @@ RSpec.describe Magic::Cards::JungleHollow do
   let(:card) { described_class.new(game: game) }
 
   let!(:permanent) do
-    action = Magic::Actions::PlayLand.new(player: p1, card: card)
-    game.take_action(action)
+    p1.play_land(land: card)
     p1.permanents.by_name("Jungle Hollow").first
   end
 
@@ -21,9 +20,7 @@ RSpec.describe Magic::Cards::JungleHollow do
   end
 
   it "taps for either black or green" do
-    action = Magic::Actions::ActivateAbility.new(player: p1, permanent: permanent, ability: card.activated_abilities.first)
-    action.pay_tap
-    game.take_action(action)
+    p1.activate_ability(ability: permanent.activated_abilities.first)
     game.resolve_pending_effect(black: 1)
     expect(game.effects).to be_empty
     expect(p1.mana_pool[:black]).to eq(1)

--- a/spec/cards/keen_glidemaster_spec.rb
+++ b/spec/cards/keen_glidemaster_spec.rb
@@ -9,10 +9,11 @@ RSpec.describe Magic::Cards::KeenGlidemaster do
     it "gives wood elves flying" do
       expect(subject.activated_abilities.count).to eq(1)
       p1.add_mana(blue: 3)
-      action = Magic::Actions::ActivateAbility.new(player: p1, permanent: subject, ability: subject.activated_abilities.first)
-        .pay_mana(generic: { blue: 2 }, blue: 1)
-        .targeting(wood_elves)
-      action.perform
+      p1.activate_ability(ability: subject.activated_abilities.first) do
+        _1
+          .pay_mana(generic: { blue: 2 }, blue: 1)
+          .targeting(wood_elves)
+      end
       expect(wood_elves).to be_flying
       expect(wood_elves.keyword_grants.first.until_eot?).to eq(true)
     end

--- a/spec/cards/lathril_blade_of_the_elves_spec.rb
+++ b/spec/cards/lathril_blade_of_the_elves_spec.rb
@@ -15,9 +15,9 @@ RSpec.describe Magic::Cards::LathrilBladeOfTheElves do
       token.resolve!(p1)
     end
 
-    action = Magic::Actions::ActivateAbility.new(permanent: subject, ability: subject.activated_abilities.first, player: p1)
-    action.pay_multi_tap(elves)
-    game.take_action(action)
+    p1.activate_ability(ability: subject.activated_abilities.first) do
+      _1.pay_multi_tap(elves)
+    end
     game.stack.resolve!
 
     expect(p1.life).to eq(p1.starting_life + 10)

--- a/spec/cards/llanowar_elves_spec.rb
+++ b/spec/cards/llanowar_elves_spec.rb
@@ -8,8 +8,7 @@ RSpec.describe Magic::Cards::LlanowarElves do
   context "when on battlefield" do
     it "can be tapped for one green mana" do
       ability = subject.activated_abilities.first
-      action = Magic::Actions::ActivateAbility.new(player: p1, permanent: subject, ability: ability)
-      game.take_action(action)
+      p1.activate_ability(ability: ability)
       expect(p1.mana_pool[:green]).to eq(1)
     end
   end

--- a/spec/cards/makeshift_batallion_spec.rb
+++ b/spec/cards/makeshift_batallion_spec.rb
@@ -16,11 +16,20 @@ RSpec.describe Magic::Cards::MakeshiftBatallion do
     it "gets a +1/+1 counter when both elves attack" do
       current_turn.declare_attackers!
 
-      action_1 = Magic::Actions::DeclareAttacker.new(player: p1, attacker: makeshift_batallion, target: p2)
-      action_2 = Magic::Actions::DeclareAttacker.new(player: p1, attacker: wood_elves_1, target: p2)
-      action_3 = Magic::Actions::DeclareAttacker.new(player: p1, attacker: wood_elves_2, target: p2)
+      p1.declare_attacker(
+        attacker: makeshift_batallion,
+        target: p2,
+      )
 
-      game.take_actions(action_1, action_2, action_3)
+      p1.declare_attacker(
+        attacker: wood_elves_1,
+        target: p2,
+      )
+
+      p1.declare_attacker(
+        attacker: wood_elves_2,
+        target: p2,
+      )
 
       current_turn.attackers_declared!
 
@@ -31,13 +40,13 @@ RSpec.describe Magic::Cards::MakeshiftBatallion do
     it "gets no counters when only one elf attacks" do
       current_turn.declare_attackers!
 
-      current_turn.declare_attacker(
-        makeshift_batallion,
+      p1.declare_attacker(
+        attacker: makeshift_batallion,
         target: p2,
       )
 
-      current_turn.declare_attacker(
-        wood_elves_1,
+      p1.declare_attacker(
+        attacker: wood_elves_1,
         target: p2,
       )
 
@@ -51,13 +60,13 @@ RSpec.describe Magic::Cards::MakeshiftBatallion do
     it "gets no counters when falconer adept attacks" do
       current_turn.declare_attackers!
 
-      current_turn.declare_attacker(
-        makeshift_batallion,
+      p1.declare_attacker(
+        attacker: makeshift_batallion,
         target: p2,
       )
 
-      current_turn.declare_attacker(
-        falconer_adept,
+      p1.declare_attacker(
+        attacker: falconer_adept,
         target: p2,
       )
 

--- a/spec/cards/mangara_the_diplomat_spec.rb
+++ b/spec/cards/mangara_the_diplomat_spec.rb
@@ -57,13 +57,14 @@ RSpec.describe Magic::Cards::MangaraTheDiplomat do
     it "p1 casts two wood elves, p2 draws" do
       expect(p2).to receive(:draw!)
       p1.add_mana({ green: 6 })
-      action = Magic::Actions::Cast.new(player: p1, card: wood_elves_1)
-      action.pay_mana(generic: { green: 2 }, green: 1)
+      p1.cast(card: wood_elves_1) do
+        _1.pay_mana(generic: { green: 2 }, green: 1)
+      end
 
-      action_2 = Magic::Actions::Cast.new(player: p1, card: wood_elves_2)
-      action_2.pay_mana(generic: { green: 2 }, green: 1)
+      p1.cast(card: wood_elves_2) do
+        _1.pay_mana(generic: { green: 2 }, green: 1)
+      end
 
-      game.take_actions(action, action_2)
       game.tick!
     end
   end

--- a/spec/cards/mountain_spec.rb
+++ b/spec/cards/mountain_spec.rb
@@ -6,9 +6,7 @@ RSpec.describe Magic::Cards::Mountain do
 
   it "taps for a single red mana" do
     expect(p1).to receive(:add_mana).with(red: 1)
-    action = Magic::Actions::ActivateAbility.new(player: p1, permanent: subject, ability: subject.activated_abilities.first)
-    action.pay_tap
-    game.take_action(action)
+    p1.activate_ability(ability: subject.activated_abilities.first)
     expect(subject).to be_tapped
   end
 end

--- a/spec/cards/plains_spec.rb
+++ b/spec/cards/plains_spec.rb
@@ -6,9 +6,7 @@ RSpec.describe Magic::Cards::Plains do
 
   it "taps for a single white mana" do
     expect(p1).to receive(:add_mana).with(white: 1)
-    action = Magic::Actions::ActivateAbility.new(player: p1, permanent: subject, ability: subject.activated_abilities.first)
-    action.pay_tap
-    game.take_action(action)
+    p1.activate_ability(ability: subject.activated_abilities.first)
     expect(subject).to be_tapped
   end
 end

--- a/spec/cards/sanctum_of_tranquil_light_spec.rb
+++ b/spec/cards/sanctum_of_tranquil_light_spec.rb
@@ -9,10 +9,11 @@ RSpec.describe Magic::Cards::SanctumOfTranquilLight do
     it "taps wood elves" do
       expect(subject.activated_abilities.count).to eq(1)
       p1.add_mana(white: 5)
-      action = Magic::Actions::ActivateAbility.new(player: p1, permanent: subject, ability: subject.activated_abilities.first)
-        .pay_mana(generic: { white: 4 }, white: 1)
-        .targeting(wood_elves)
-      game.take_action(action)
+      p1.activate_ability(ability: subject.activated_abilities.first) do
+        _1
+          .pay_mana(generic: { white: 4 }, white: 1)
+          .targeting(wood_elves)
+      end
       game.stack.resolve!
       expect(wood_elves).to be_tapped
     end

--- a/spec/cards/scavenging_ooze_spec.rb
+++ b/spec/cards/scavenging_ooze_spec.rb
@@ -20,10 +20,11 @@ RSpec.describe Magic::Cards::ScavengingOoze do
       it "exiles a card from a graveyard, adds +1/1 counter and p1 gains life" do
         p1.add_mana(green: 1)
         starting_life = p1.life
-        action = Magic::Actions::ActivateAbility.new(player: p1, permanent: scavenging_ooze, ability: ability)
-        action.pay_mana(green: 1)
-        action.targeting(wood_elves)
-        game.take_action(action)
+        p1.activate_ability(ability: ability) do
+          _1
+            .pay_mana(green: 1)
+            .targeting(wood_elves)
+        end
         game.stack.resolve!
 
         aggregate_failures do
@@ -47,10 +48,11 @@ RSpec.describe Magic::Cards::ScavengingOoze do
       it "exiles sol ring, does not add counter and p1 does not gain life" do
         p1.add_mana(green: 1)
         starting_life = p1.life
-        action = Magic::Actions::ActivateAbility.new(player: p1, permanent: scavenging_ooze, ability: ability)
-        action.pay_mana(green: 1)
-        action.targeting(sol_ring)
-        game.take_action(action)
+        p1.activate_ability(ability: ability) do
+          _1
+            .pay_mana(green: 1)
+            .targeting(sol_ring)
+        end
         game.stack.resolve!
 
         aggregate_failures do

--- a/spec/cards/scute_swarm_spec.rb
+++ b/spec/cards/scute_swarm_spec.rb
@@ -13,8 +13,7 @@ RSpec.describe Magic::Cards::ScuteSwarm do
     context "when controller controls less than 6 lands" do
       it "creates an insect" do
         subject
-        action = Magic::Actions::PlayLand.new(player: p1, card: forest)
-        game.take_action(action)
+        p1.play_land(land: forest)
         game.tick!
 
         expect(game.battlefield.creatures.controlled_by(p1).by_name("Insect").count).to eq(1)
@@ -28,8 +27,7 @@ RSpec.describe Magic::Cards::ScuteSwarm do
 
       it "creates a token copy of Scute Swarm" do
         subject
-        action = Magic::Actions::PlayLand.new(player: p1, card: forest)
-        game.take_action(action)
+        p1.play_land(land: forest)
         game.tick!
 
         scutes = game.battlefield.creatures.controlled_by(p1).by_name("Scute Swarm")
@@ -47,8 +45,7 @@ RSpec.describe Magic::Cards::ScuteSwarm do
       it "creates a token copy of Scute Swarm" do
         subject
         ResolvePermanent("Scute Swarm", owner: p1)
-        action = Magic::Actions::PlayLand.new(player: p1, card: forest)
-        game.take_action(action)
+        p1.play_land(land: forest)
         game.tick!
 
         scutes = game.battlefield.creatures.controlled_by(p1).by_name("Scute Swarm")

--- a/spec/cards/seasoned_hallowblade_spec.rb
+++ b/spec/cards/seasoned_hallowblade_spec.rb
@@ -12,9 +12,9 @@ RSpec.describe Magic::Cards::SeasonedHallowblade do
   context "activated ability" do
     it "taps hallowblade, applies indestructible until eot" do
       expect(subject.activated_abilities.count).to eq(1)
-      action = Magic::Actions::ActivateAbility.new(player: p1, permanent: subject, ability: subject.activated_abilities.first)
-        .pay(p1, :discard, p1.hand.cards.first)
-      game.take_action(action)
+      p1.activate_ability(ability: subject.activated_abilities.first) do
+        _1.pay(:discard, p1.hand.cards.first)
+      end
       expect(subject).to be_tapped
       expect(subject).to be_indestructible
       expect(subject.keyword_grants.count).to eq(1)

--- a/spec/cards/secure_the_scene_spec.rb
+++ b/spec/cards/secure_the_scene_spec.rb
@@ -10,10 +10,10 @@ RSpec.describe Magic::Cards::SecureTheScene do
 
     it "exiles the wood elves, replaces them with a 1/1 White Soldier" do
       p1.add_mana(white: 5)
-      action = Magic::Actions::Cast.new(player: p1, card: secure_the_scene)
-        .pay_mana(generic: { white: 4 }, white: 1)
-        .targeting(wood_elves)
-      game.take_action(action)
+      p1.cast(card: secure_the_scene) do
+        _1.pay_mana(generic: { white: 4 }, white: 1)
+          .targeting(wood_elves)
+      end
       game.tick!
 
       expect(wood_elves.card.zone).to be_exile

--- a/spec/cards/selfless_savior_spec.rb
+++ b/spec/cards/selfless_savior_spec.rb
@@ -12,10 +12,9 @@ RSpec.describe Magic::Cards::SelflessSavior do
     end
 
     it "sacrifices selfless, applies indestructible to elves until eot" do
-      action = Magic::Actions::ActivateAbility.new(player: p1, permanent: subject, ability: subject.activated_abilities.first)
-        .pay(p1, :sacrifice, subject)
-        .targeting(wood_elves)
-      game.take_action(action)
+      p1.activate_ability(ability: ability) do
+        _1.pay(:sacrifice, subject).targeting(wood_elves)
+      end
       expect(wood_elves).to be_indestructible
       expect(wood_elves.keyword_grants.first.until_eot?).to eq(true)
     end

--- a/spec/cards/shock_spec.rb
+++ b/spec/cards/shock_spec.rb
@@ -9,10 +9,9 @@ RSpec.describe Magic::Cards::Shock do
 
   it "destroys the Cloudkin Seer" do
     p1.add_mana(red: 1)
-    action = Magic::Actions::Cast.new(player: p1, card: shock)
-        .pay_mana(red: 1)
-        .targeting(cloudkin_seer)
-    game.take_action(action)
+    p1.cast(card: shock) do
+      _1.pay_mana(red: 1).targeting(cloudkin_seer)
+    end
     game.tick!
     expect(cloudkin_seer).to be_dead
   end
@@ -20,21 +19,19 @@ RSpec.describe Magic::Cards::Shock do
   it "targets the opponent" do
     p2_life_total = p2.life
     p1.add_mana(red: 1)
-    action = Magic::Actions::Cast.new(player: p1, card: shock)
-      .pay_mana(red: 1)
-      .targeting(p2)
-    game.take_action(action)
+    p1.cast(card: shock) do
+      _1.pay_mana(red: 1).targeting(p2)
+    end
     game.tick!
     expect(p2.life).to eq(p2_life_total - 2)
   end
 
   it "removes planeswalker loyalty" do
     p1.add_mana(red: 1)
-    action = Magic::Actions::Cast.new(player: p1, card: shock)
-      .pay_mana(red: 1)
-      .targeting(basri_ket)
-    game.take_action(action)
+    p1.cast(card: shock) do
+      _1.pay_mana(red: 1).targeting(basri_ket)
+    end
     game.tick!
     expect(basri_ket.loyalty).to eq(1)
-  end 
+  end
 end

--- a/spec/cards/siege_striker_spec.rb
+++ b/spec/cards/siege_striker_spec.rb
@@ -22,7 +22,7 @@ RSpec.describe Magic::Cards::SiegeStriker do
       expect(siege_striker.power).to eq(1)
       expect(siege_striker.toughness).to eq(1)
 
-      action = Magic::Actions::TapPermanent.new(player: p1, permanent: wood_elves)
+      action = Magic::Actions::TapPermanent.new(game: game, player: p1, permanent: wood_elves)
       game.take_action(action)
 
       expect(siege_striker.power).to eq(2)
@@ -33,7 +33,7 @@ RSpec.describe Magic::Cards::SiegeStriker do
       expect(siege_striker.power).to eq(1)
       expect(siege_striker.toughness).to eq(1)
 
-      action = Magic::Actions::TapPermanent.new(player: p1, permanent: wood_elves)
+      action = Magic::Actions::TapPermanent.new(game: game, player: p1, permanent: wood_elves)
       game.take_action(action)
 
       expect(siege_striker.power).to eq(1)

--- a/spec/cards/sol_ring_spec.rb
+++ b/spec/cards/sol_ring_spec.rb
@@ -6,9 +6,7 @@ RSpec.describe Magic::Cards::SolRing do
 
   context "tap" do
     it "taps for two colorless mana" do
-      action = Magic::Actions::ActivateAbility.new(player: p1, permanent: subject, ability: subject.activated_abilities.first)
-      action.pay_tap
-      game.take_action(action)
+      p1.activate_ability(ability: subject.activated_abilities.first)
       expect(p1.mana_pool[:colorless]).to eq(2)
     end
   end

--- a/spec/cards/speaker_of_the_heavens_spec.rb
+++ b/spec/cards/speaker_of_the_heavens_spec.rb
@@ -14,7 +14,7 @@ RSpec.describe Magic::Cards::SpeakerOfTheHeavens do
   it "activated ability" do
     p1.gain_life(7)
     ability = speaker_of_the_heavens.activated_abilities.first
-    action = Magic::Actions::ActivateAbility.new(player: p1, permanent: speaker_of_the_heavens, ability: ability)
+    action = p1.prepare_activate_ability(ability: ability)
     expect(action.can_be_activated?(p1)).to eq(true)
     action.pay_tap
     action.finalize_costs!(p1)

--- a/spec/cards/sure_strike_spec.rb
+++ b/spec/cards/sure_strike_spec.rb
@@ -6,14 +6,13 @@ RSpec.describe Magic::Cards::SureStrike do
   let!(:sure_strike) { described_class.new(game: game) }
   let!(:onakke_ogre) { ResolvePermanent("Onakke Ogre", owner: p1) }
   context "with a creature in play" do
-    
+
 
     it "grants first strike and 3 power" do
       p1.add_mana(red: 2)
-      action = Magic::Actions::Cast.new(player: p1, card: sure_strike)
-        .pay_mana(generic: { red: 1 }, red: 1)
-        .targeting(onakke_ogre)
-      game.take_action(action)
+      p1.cast(card: sure_strike) do
+        _1.pay_mana(generic: { red: 1 }, red: 1).targeting(onakke_ogre)
+      end
       game.tick!
 
       expect(onakke_ogre.power).to eq(7)

--- a/spec/cards/swamp_spec.rb
+++ b/spec/cards/swamp_spec.rb
@@ -6,9 +6,7 @@ RSpec.describe Magic::Cards::Swamp do
 
   it "taps for a single white mana" do
     expect(p1).to receive(:add_mana).with(black: 1)
-    action = Magic::Actions::ActivateAbility.new(player: p1, permanent: subject, ability: subject.activated_abilities.first)
-    action.pay_tap
-    game.take_action(action)
+    p1.activate_ability(ability: subject.activated_abilities.first)
     expect(subject).to be_tapped
   end
 end

--- a/spec/cards/tempered_veteran_spec.rb
+++ b/spec/cards/tempered_veteran_spec.rb
@@ -12,22 +12,13 @@ RSpec.describe Magic::Cards::TemperedVeteran do
     it "adds a counter to a creature with a counter" do
       p1.add_mana(white: 2)
       wood_elves.add_counter(Magic::Counters::Plus1Plus1)
-      action = Magic::Actions::ActivateAbility.new(player: p1, permanent: tempered_veteran, ability: ability)
-      action.targeting(wood_elves)
-      action.pay_mana({ white: 1 })
-      action.pay_tap
-      action.finalize_costs!(p1)
-
-      game.take_action(action)
+      p1.activate_ability(ability: ability) do
+        _1.targeting(wood_elves).pay_mana(white: 1)
+      end
       game.tick!
 
       expect(tempered_veteran).to be_tapped
       expect(wood_elves.counters.of_type(Magic::Counters::Plus1Plus1).count).to eq(2)
-    end
-
-    it "cannot add a counter to a creature without a counter" do
-      action = Magic::Actions::ActivateAbility.new(player: p1, permanent: tempered_veteran, ability: ability)
-      expect(action.valid_targets?(wood_elves)).to eq(false)
     end
   end
 
@@ -36,13 +27,9 @@ RSpec.describe Magic::Cards::TemperedVeteran do
 
     it "adds a counter to a creature without a counter" do
       p1.add_mana(white: 6)
-      action = Magic::Actions::ActivateAbility.new(player: p1, permanent: tempered_veteran, ability: ability)
-      action.targeting(wood_elves)
-      action.pay_mana({ generic: { white: 4 }, white: 2 })
-      action.pay_tap
-      action.finalize_costs!(p1)
-
-      game.take_action(action)
+      p1.activate_ability(ability: ability) do
+        _1.targeting(wood_elves).pay_mana({ generic: { white: 4 }, white: 2 })
+      end
       game.tick!
 
       expect(tempered_veteran).to be_tapped

--- a/spec/cards/ugin_the_spirit_dragon_spec.rb
+++ b/spec/cards/ugin_the_spirit_dragon_spec.rb
@@ -10,9 +10,9 @@ RSpec.describe Magic::Cards::UginTheSpiritDragon do
     let(:wood_elves) { ResolvePermanent("Wood Elves", owner: p2) }
 
     it "targets the wood elves" do
-      action = Magic::Actions::ActivateLoyaltyAbility.new(player: p1, planeswalker: ugin, ability: ability)
-        .targeting(wood_elves)
-      game.take_action(action)
+      p1.activate_loyalty_ability(ability: ability) do
+        _1.targeting(wood_elves)
+      end
       game.stack.resolve!
       expect(subject.loyalty).to eq(9)
       expect(wood_elves.damage).to eq(3)
@@ -20,9 +20,9 @@ RSpec.describe Magic::Cards::UginTheSpiritDragon do
 
     it "targets the other player" do
       p2_starting_life = p2.life
-      action = Magic::Actions::ActivateLoyaltyAbility.new(player: p1, planeswalker: ugin, ability: ability)
-        .targeting(p2)
-      game.take_action(action)
+      p1.activate_loyalty_ability(ability: ability) do
+        _1.targeting(p2)
+      end
       game.stack.resolve!
       expect(p2.life).to eq(p2_starting_life - 3)
     end
@@ -34,9 +34,9 @@ RSpec.describe Magic::Cards::UginTheSpiritDragon do
     let!(:sol_ring) { ResolvePermanent("Sol Ring", owner: p2) }
 
     it "exiles wood elves, leaves the sol ring" do
-      action = Magic::Actions::ActivateLoyaltyAbility.new(player: p1, planeswalker: ugin, ability: ability)
-        .value_for_x(3)
-      game.take_action(action)
+      p1.activate_loyalty_ability(ability: ability) do
+        _1.value_for_x(3)
+      end
       game.stack.resolve!
       expect(subject.loyalty).to eq(4)
       # Wood elves has a color, so it goes
@@ -68,8 +68,7 @@ RSpec.describe Magic::Cards::UginTheSpiritDragon do
     end
 
     it "controller gains 7 life, draws 7 cards and moves 7 permanents to the battlefield" do
-      action = Magic::Actions::ActivateLoyaltyAbility.new(player: p1, planeswalker: ugin, ability: ability)
-      game.take_action(action)
+      p1.activate_loyalty_ability(ability: ability)
       game.stack.resolve!
       expect(subject.loyalty).to eq(0)
       expect(subject.zone).to be_nil

--- a/spec/costs/mana_spec.rb
+++ b/spec/costs/mana_spec.rb
@@ -67,6 +67,23 @@ RSpec.describe Magic::Costs::Mana do
   context "pay" do
     let(:player) { Magic::Player.new }
 
+
+    context "when cost is 1 red" do
+      subject { described_class.new({ red: 1 }) }
+      context "can pay a card's cost" do
+        let(:card) { Magic::Cards::LightningBolt.new }
+
+        before do
+          player.add_mana(red: 1)
+        end
+
+        it "can pay and finalize" do
+          subject.pay(player, card.cost)
+          subject.finalize!(player)
+        end
+      end
+    end
+
     context "when cost is 1 generic, 1 red" do
       subject { described_class.new({ generic: 1, red: 1 }) }
 

--- a/spec/costs/mana_spec.rb
+++ b/spec/costs/mana_spec.rb
@@ -67,23 +67,6 @@ RSpec.describe Magic::Costs::Mana do
   context "pay" do
     let(:player) { Magic::Player.new }
 
-
-    context "when cost is 1 red" do
-      subject { described_class.new({ red: 1 }) }
-      context "can pay a card's cost" do
-        let(:card) { Magic::Cards::LightningBolt.new }
-
-        before do
-          player.add_mana(red: 1)
-        end
-
-        it "can pay and finalize" do
-          subject.pay(player, card.cost)
-          subject.finalize!(player)
-        end
-      end
-    end
-
     context "when cost is 1 generic, 1 red" do
       subject { described_class.new({ generic: 1, red: 1 }) }
 

--- a/spec/game/integration/attackers_declared_spec.rb
+++ b/spec/game/integration/attackers_declared_spec.rb
@@ -13,8 +13,7 @@ RSpec.describe Magic::Game, "attackers declared" do
   context "with basri ket's delayed trigger" do
     before do
       basri_ket.change_loyalty!(7)
-      action = Magic::Actions::ActivateLoyaltyAbility.new(player: p1, planeswalker: basri_ket, ability: basri_ket.loyalty_abilities[1])
-      game.take_action(action)
+      p1.activate_loyalty_ability(ability: basri_ket.loyalty_abilities[1])
       game.stack.resolve!
     end
 

--- a/spec/game/integration/mana/essence_warden_spec.rb
+++ b/spec/game/integration/mana/essence_warden_spec.rb
@@ -11,9 +11,8 @@ RSpec.describe Magic::Game, "Mana spend -- Essence Warden" do
       end
 
       it "cannot cast the essence warden" do
-        action = Magic::Actions::Cast.new(player: p1, card: essence_warden)
+        action = p1.prepare_cast(card: essence_warden)
         expect(action.can_perform?).to eq(false)
-
       end
     end
 
@@ -27,16 +26,14 @@ RSpec.describe Magic::Game, "Mana spend -- Essence Warden" do
       end
 
       it "casts a forest, then an essence warden" do
-        action = Magic::Actions::Cast.new(player: p1, card: forest)
-        expect(action.can_perform?).to eq(true)
-        game.take_action(action)
+        p1.play_land(land: forest)
         game.tick!
 
         forest = p1.permanents.by_name("Forest").first
-        action = Magic::Actions::ActivateAbility.new(player: p1, permanent: forest, ability: forest.activated_abilities.first)
-        game.take_action(action)
+        p1.activate_ability(ability: forest.activated_abilities.first)
         expect(p1.mana_pool[:green]).to eq(1)
-        action = Magic::Actions::Cast.new(player: p1, card: essence_warden)
+
+        action = p1.prepare_cast(card: essence_warden)
         expect(action.can_perform?).to eq(true)
         action.pay_mana(green: 1)
         game.take_action(action)

--- a/spec/game/integration/mana/foundry_inspector_sol_ring_spec.rb
+++ b/spec/game/integration/mana/foundry_inspector_sol_ring_spec.rb
@@ -22,17 +22,17 @@ RSpec.describe Magic::Game, "Mana spend -- Foundry Inspector + Free Sol Ring" do
 
       it "casts a foundry inspector and then a sol ring" do
         p1.add_mana(red: 3)
-        action = Magic::Actions::Cast.new(player: p1, card: foundry_inspector)
-        expect(action.can_perform?).to eq(true)
-        action.pay_mana(generic: { red: 3 } )
-        game.take_action(action)
-        game.tick!
-
-        action = Magic::Actions::Cast.new(player: p1, card: sol_ring)
-        expect(action.can_perform?).to eq(true)
-        game.take_action(action)
+        p1.cast(card: foundry_inspector) do
+          _1.pay_mana(generic: { red: 3 })
+        end
 
         game.tick!
+
+        # Sol Ring cost discounted by 1 by Foundry Inspector, so is free
+        p1.cast(card: sol_ring)
+
+        game.tick!
+
         expect(p1.permanents.by_name(sol_ring.name).count).to eq(1)
       end
     end

--- a/spec/spec_helper.rb
+++ b/spec/spec_helper.rb
@@ -25,9 +25,9 @@ module CardHelper
     card
   end
 
-  def cast_action(card:, player:, targeting: nil)
-    action = Magic::Actions::Cast.new(card: card, player: player)
-    action.targeting(targeting) if targeting
+  def cast_action(card:, player:, targeting: nil, &block)
+    action = Magic::Actions::Cast.new(card: card, player: player, game: game)
+    yield action if block_given?
     action
   end
 
@@ -36,8 +36,8 @@ module CardHelper
     game.stack.resolve!
   end
 
-  def cast_and_resolve(card:, player:, targeting: nil)
-    action = cast_action(card: card, player: player, targeting: targeting)
+  def cast_and_resolve(card:, player:, targeting: nil, &block)
+    action = cast_action(card: card, player: player, targeting: targeting, &block)
     game.stack.add(action)
     game.stack.resolve!
   end

--- a/spec/spec_helper.rb
+++ b/spec/spec_helper.rb
@@ -27,6 +27,7 @@ module CardHelper
 
   def cast_action(card:, player:, targeting: nil, &block)
     action = Magic::Actions::Cast.new(card: card, player: player, game: game)
+    action.targeting(targeting) if targeting
     yield action if block_given?
     action
   end


### PR DESCRIPTION
## Before

```
action = Magic::Actions::ActivateAbility.new(player: p1, permanent: island, ability: island.activated_abilities.first)
```

## After

```
p1.activate_ability(ability: island.activated_abilities.first)
```

Abilities are now tied to the permanent they're from. IOW, going from ability -> permanent now rather than permanent -> abilities.