### PR TITLE
Test Spirit creature remaining on the battlefield

### DIFF
--- a/spec/cards/roaming_ghostlight_spec.rb
+++ b/spec/cards/roaming_ghostlight_spec.rb
@@ -4,7 +4,8 @@ RSpec.describe Magic::Cards::RoamingGhostlight do
   include_context "two player game"
 
   before do
-    ResolvePermanent("Wood Elves", owner: p2)
+    ResolvePermanent("Wood Elves", owner: p2) # Non-spirit creature
+    ResolvePermanent("Wandering Ones", owner: p2) # Spirit creature
   end
 
   context "when it enters the battlefield" do
@@ -12,6 +13,9 @@ RSpec.describe Magic::Cards::RoamingGhostlight do
       ResolvePermanent("Roaming Ghostlight", owner: p1)
 
       expect(p2.hand.by_name("Wood Elves").count).to eq(1)
+
+      expect(game.battlefield.creatures.by_name("Wandering Ones").count).to eq(1)
+      expect(p2.hand.by_name("Wandering Ones").count).to eq(0)
     end
   end
 end


### PR DESCRIPTION
Hey Ryan! I checked out https://github.com/radar/mtg/commit/bcbe586f72ae274f7b8bd04ca3e1564ab33f3352 (introducing Roaming Ghostlight) after you [tooted about it](https://ruby.social/@Ryanbigg/111773205010874197) last week.

I loved how clear the test was - even I as a non-MTG-er (at least, not since 1998!) and as a newcomer to this codebase could understand it easily!

I noticed that the test only tested for one side of the card's behaviour — the returning of the non-Spirit creatures to their owners' hands. I thought it could be made more robust by testing the other side: that Spirit creatures themselves remain on the battlefield.

I mostly just contributed this as a curiosity and a chance to check out your hobby project. Feel free to take this change or leave it, I don't mind! Thanks for sharing great Ruby stuff with the world ❤️ 