### PR TITLE
correct class name on Alpha Tyrranax

### DIFF
--- a/lib/magic/cards/alpha_tyrranax.rb
+++ b/lib/magic/cards/alpha_tyrranax.rb
@@ -1,6 +1,6 @@
 module Magic
   module Cards
-    AlphaTyrrannax = Creature("Alpha Tyrranax") do
+    AlphaTyrranax = Creature("Alpha Tyrranax") do
       cost generic: 4, green: 2
       creature_type("Beast")
       power 6


### PR DESCRIPTION
when using inside Rails with `RACK_ENV=production`, a bunch of Zeitwerk autoloads happen and this one fails:

```
/usr/local/bundle/ruby/3.3.0/gems/zeitwerk-2.6.12/lib/zeitwerk/loader/callbacks.rb:33:in `on_file_autoloaded': expected file /usr/local/bundle/ruby/3.3.0/bundler/gems/mtg-581ba0a9dc3c/lib/magic/cards/alpha_tyrranax.rb to define constant Magic::Cards::AlphaTyrranax, but didn't (Zeitwerk::NameError)

      raise Zeitwerk::NameError.new(msg, cref.last)
```

https://gatherer.wizards.com/Pages/Card/Details.aspx?name=Alpha+Tyrranax

Ruby file used 2 `n` in the class name, Zeitwerk expects string matches between Class and File name. patch should resolve. (I didn't test yet, I just `rm'd` the offending file and my docker builds for my Rails app take 10 minutes)