### PR TITLE
Implement iterative replacement-effect resolution loop

### DIFF
--- a/lib/magic/game.rb
+++ b/lib/magic/game.rb
@@ -97,17 +97,7 @@ module Magic
     end
 
     def add_effect(effect)
-      replacement_effects = battlefield.map { _1.replacement_effect_for(effect) }.compact
-      if replacement_effects.any?
-        effect = replacement_effects.inject(effect) do |effect, replacement_effect|
-          new_effect = replacement_effect.call(effect)
-          logger.debug "EFFECT REPLACED!"
-          logger.debug "  Original: #{effect}"
-          logger.debug "  Replacer: #{replacement_effect}"
-          logger.debug "  New Effect: #{new_effect}"
-          new_effect
-        end
-      end
+      effect = Game::ReplacementEffectResolver.new(game: self).resolve(effect)
 
       logger.debug "Resolving effect: #{effect}"
       effect.resolve!

--- a/lib/magic/game/replacement_effect_resolver.rb
+++ b/lib/magic/game/replacement_effect_resolver.rb
@@ -1,0 +1,61 @@
+module Magic
+  class Game
+    class ReplacementEffectResolver
+      def initialize(game:)
+        @game = game
+      end
+
+      def resolve(effect)
+        current_effect = effect
+        applied_replacement_keys = []
+
+        loop do
+          replacement_effect = next_replacement_effect(
+            effect: current_effect,
+            applied_replacement_keys: applied_replacement_keys,
+          )
+          break unless replacement_effect
+
+          new_effect = replacement_effect.call(current_effect)
+          logger.debug "EFFECT REPLACED!"
+          logger.debug "  Original: #{current_effect}"
+          logger.debug "  Replacer: #{replacement_effect}"
+          logger.debug "  New Effect: #{new_effect}"
+
+          applied_replacement_keys << replacement_key_for(replacement_effect)
+          current_effect = new_effect
+        end
+
+        current_effect
+      end
+
+      private
+
+      attr_reader :game
+
+      def logger
+        game.logger
+      end
+
+      def battlefield
+        game.battlefield
+      end
+
+      def next_replacement_effect(effect:, applied_replacement_keys:)
+        battlefield.each do |permanent|
+          replacement_effect = permanent.replacement_effect_for(
+            effect,
+            applied_replacement_keys: applied_replacement_keys,
+          )
+          return replacement_effect if replacement_effect
+        end
+
+        nil
+      end
+
+      def replacement_key_for(replacement_effect)
+        [replacement_effect.receiver.object_id, replacement_effect.class]
+      end
+    end
+  end
+end

--- a/lib/magic/permanent.rb
+++ b/lib/magic/permanent.rb
@@ -155,9 +155,12 @@ module Magic
       @zone = new_zone.battlefield? ? new_zone : nil
     end
 
-    def replacement_effect_for(effect)
+    def replacement_effect_for(effect, applied_replacement_keys: [])
       replacement_effect = card.replacement_effects[effect.class]
       if replacement_effect
+        replacement_key = [object_id, replacement_effect]
+        return if applied_replacement_keys.include?(replacement_key)
+
         replacement = replacement_effect.new(receiver: self)
         replacement if replacement.applies?(effect)
       end

--- a/spec/cards/nine_lives_spec.rb
+++ b/spec/cards/nine_lives_spec.rb
@@ -7,4 +7,24 @@ RSpec.describe Magic::Cards::NineLives do
   it "has hexproof" do
     expect(card.hexproof?).to eq(true)
   end
+
+  context "when replacement creates a new replaceable effect" do
+    let!(:nine_lives) { ResolvePermanent("Nine Lives", owner: p1) }
+    let!(:doubling_season) { ResolvePermanent("Doubling Season", owner: p1) }
+    let!(:attacker) { ResolvePermanent("Wood Elves", owner: p2) }
+
+    it "re-checks replacement effects and doubles the Nine Lives counter" do
+      effect = Magic::Effects::DealDamage.new(
+        source: attacker,
+        target: p1,
+        damage: 1,
+      )
+
+      game.add_effect(effect)
+
+      incarnation_counters = nine_lives.counters.of_type(Magic::Counters::Incarnation).count
+      expect(incarnation_counters).to eq(2)
+      expect(p1.life).to eq(20)
+    end
+  end
 end


### PR DESCRIPTION
## Summary
This PR replaces the previous single-pass replacement effect application with an iterative resolver that re-checks applicability after each replacement is applied.

This closes a correctness gap where one replacement effect can transform an effect into a new effect that should itself be replaceable in the same chain.

## Why
The previous implementation in `Magic::Game#add_effect` gathered replacement effects once and applied them in a fixed inject pass. That approach could miss newly applicable replacement effects created by earlier replacements.

Example:
- `Nine Lives` replaces damage with adding an incarnation counter.
- `Doubling Season` should then apply to that counter-adding effect.
- Without re-checking, the second replacement may be skipped.

## What Changed
1. Added a dedicated resolver:
- `lib/magic/game/replacement_effect_resolver.rb`

2. Updated game effect resolution:
- `lib/magic/game.rb`
- `Game#add_effect` now delegates replacement handling to `Game::ReplacementEffectResolver`.

3. Updated replacement lookup API:
- `lib/magic/permanent.rb`
- `replacement_effect_for` now accepts `applied_replacement_keys:` so the same replacement source/class is not re-applied in the same chain.

4. Added regression coverage:
- `spec/cards/nine_lives_spec.rb`
- New scenario verifies damage replaced by `Nine Lives` is then further replaced by `Doubling Season`, resulting in 2 incarnation counters and no life loss.

## Behavior Notes
- Replacements are now applied one at a time.
- After each replacement, candidates are re-evaluated against the transformed effect.
- Re-applying the same replacement source/class in the same chain is prevented.
- Ordering remains deterministic by battlefield iteration for now; affected-player/controller choice ordering is planned for PR 2.

## Files Included In This PR
- `lib/magic/game.rb`
- `lib/magic/game/replacement_effect_resolver.rb`
- `lib/magic/permanent.rb`
- `spec/cards/nine_lives_spec.rb`

## Test Evidence
Targeted replacement specs:
- `bundle exec rspec spec/cards/nine_lives_spec.rb spec/cards/doubling_season_spec.rb spec/cards/conclave_mentor_spec.rb`
- Result: passing

Full suite:
- `bundle exec rspec`
- Result: 520 examples, 0 failures

## Follow-up
Planned in PR 2:
- Introduce affected-player/affected-permanent-controller choice for replacement ordering when multiple replacements apply.
