### PR TITLE
PR 2: Explicit chooser-driven replacement ordering

### DIFF
--- a/docs/prs/pr-002-replacement-chooser-ordering.md
+++ b/docs/prs/pr-002-replacement-chooser-ordering.md
@@ -1,0 +1,56 @@
+# PR 2: Explicit chooser-driven replacement ordering
+
+## Summary
+This PR introduces an explicit replacement-effect chooser step during replacement resolution.
+
+When multiple replacement effects apply to the same effect, the engine now delegates selection to a chooser determined from the affected object/player, rather than relying on incidental battlefield iteration order.
+
+## Why
+PR 1 added iterative re-checking. However, replacement selection still implicitly depended on traversal order.
+
+Rules behavior requires a choice point for ordering when multiple replacements apply. This PR makes that ordering explicit and testable.
+
+## What Changed
+1. Added chooser hook in game:
+- `lib/magic/game.rb`
+- New `choose_replacement_effect(effect:, replacement_effects:)`
+- New chooser inference (`replacement_effect_chooser_for`) from affected target/permanent/controller.
+
+2. Added default chooser behavior for players:
+- `lib/magic/player.rb`
+- New `choose_replacement_effect(effect:, replacement_effects:)` default strategy returns first option (deterministic baseline).
+
+3. Updated replacement resolver to gather all current candidates and delegate choice:
+- `lib/magic/game/replacement_effect_resolver.rb`
+- Replaced single next-effect fetch with candidate list + chooser selection.
+
+4. Added ordering-sensitive integration test:
+- `spec/game/integration/replacement_effect_choice_order_spec.rb`
+- Uses `Doubling Season` + `Conclave Mentor` on a `+1/+1` counter effect.
+- Verifies different chooser preference yields different outcomes (3 vs 4 counters).
+
+## Behavior Notes
+- Replacement resolution remains iterative from PR 1.
+- Selection among currently applicable replacements is now explicit via chooser.
+- Default chooser remains deterministic for now; richer user-facing choice UX can be layered in later.
+
+## Files Included In This PR
+- `lib/magic/game.rb`
+- `lib/magic/player.rb`
+- `lib/magic/game/replacement_effect_resolver.rb`
+- `spec/game/integration/replacement_effect_choice_order_spec.rb`
+
+## Test Evidence
+Targeted:
+- `bundle exec rspec spec/game/integration/replacement_effect_choice_order_spec.rb spec/cards/doubling_season_spec.rb spec/cards/conclave_mentor_spec.rb spec/cards/nine_lives_spec.rb`
+- Result: passing
+
+Full suite:
+- `bundle exec rspec`
+- Result: 522 examples, 0 failures
+
+## Follow-up
+Potential PR 3+ enhancements:
+- Replace default deterministic chooser with proper choice prompts.
+- Expand chooser inference into a richer replacement-context object.
+- Cover APNAP and cross-controller interactions with dedicated integration tests.

--- a/lib/magic/game.rb
+++ b/lib/magic/game.rb
@@ -103,6 +103,15 @@ module Magic
       effect.resolve!
     end
 
+    def choose_replacement_effect(effect:, replacement_effects:)
+      chooser = replacement_effect_chooser_for(effect)
+      if chooser
+        chooser.choose_replacement_effect(effect: effect, replacement_effects: replacement_effects)
+      else
+        replacement_effects.first
+      end
+    end
+
     def tick!
       battlefield.map(&:apply_continuous_effects!)
       check_for_state_triggered_abilities
@@ -125,6 +134,26 @@ module Magic
 
     def move_dead_creatures_to_graveyard
       battlefield.creatures.dead.each(&:destroy!)
+    end
+
+    private
+
+    def replacement_effect_chooser_for(effect)
+      if effect.respond_to?(:target)
+        target = effect.target
+        return target if target.respond_to?(:player?) && target.player?
+        return target.controller if target.respond_to?(:controller)
+      end
+
+      if effect.respond_to?(:controller)
+        return effect.controller
+      end
+
+      if effect.respond_to?(:permanent) && effect.permanent.respond_to?(:controller)
+        return effect.permanent.controller
+      end
+
+      nil
     end
   end
 end

--- a/lib/magic/game/replacement_effect_resolver.rb
+++ b/lib/magic/game/replacement_effect_resolver.rb
@@ -10,9 +10,15 @@ module Magic
         applied_replacement_keys = []
 
         loop do
-          replacement_effect = next_replacement_effect(
+          replacement_effects = applicable_replacement_effects(
             effect: current_effect,
             applied_replacement_keys: applied_replacement_keys,
+          )
+          break if replacement_effects.empty?
+
+          replacement_effect = game.choose_replacement_effect(
+            effect: current_effect,
+            replacement_effects: replacement_effects,
           )
           break unless replacement_effect
 
@@ -41,16 +47,13 @@ module Magic
         game.battlefield
       end
 
-      def next_replacement_effect(effect:, applied_replacement_keys:)
-        battlefield.each do |permanent|
-          replacement_effect = permanent.replacement_effect_for(
+      def applicable_replacement_effects(effect:, applied_replacement_keys:)
+        battlefield.filter_map do |permanent|
+          permanent.replacement_effect_for(
             effect,
             applied_replacement_keys: applied_replacement_keys,
           )
-          return replacement_effect if replacement_effect
         end
-
-        nil
       end
 
       def replacement_key_for(replacement_effect)

--- a/lib/magic/player.rb
+++ b/lib/magic/player.rb
@@ -287,6 +287,10 @@ module Magic
       end
     end
 
+    def choose_replacement_effect(effect:, replacement_effects:)
+      replacement_effects.first
+    end
+
     def protected_from?(card)
       permanents.flat_map { |card| card.protections.player }.any? { |protection| protection.protected_from?(card) }
     end

--- a/spec/game/integration/replacement_effect_choice_order_spec.rb
+++ b/spec/game/integration/replacement_effect_choice_order_spec.rb
@@ -1,0 +1,46 @@
+require 'spec_helper'
+
+RSpec.describe Magic::Game, "replacement effects -- chooser controls application order" do
+  include_context "two player game"
+
+  let!(:doubling_season) { ResolvePermanent("Doubling Season", owner: p1) }
+  let!(:conclave_mentor) { ResolvePermanent("Conclave Mentor", owner: p1) }
+  let!(:wood_elves) { ResolvePermanent("Wood Elves", owner: p1) }
+
+  def counter_effect
+    Magic::Effects::AddCounterToPermanent.new(
+      source: wood_elves,
+      counter_type: Magic::Counters::Plus1Plus1,
+      target: wood_elves,
+      amount: 1,
+    )
+  end
+
+  context "when chooser applies doubling season first" do
+    before do
+      allow(p1).to receive(:choose_replacement_effect) do |replacement_effects:, **_args|
+        replacement_effects.find { |effect| effect.is_a?(Magic::Cards::DoublingSeason::CounterDoubler) } || replacement_effects.first
+      end
+    end
+
+    it "adds 3 counters" do
+      game.add_effect(counter_effect)
+
+      expect(wood_elves.counters.of_type(Magic::Counters::Plus1Plus1).count).to eq(3)
+    end
+  end
+
+  context "when chooser applies conclave mentor first" do
+    before do
+      allow(p1).to receive(:choose_replacement_effect) do |replacement_effects:, **_args|
+        replacement_effects.find { |effect| effect.is_a?(Magic::Cards::ConclaveMentor::AddMoreCounters) } || replacement_effects.first
+      end
+    end
+
+    it "adds 4 counters" do
+      game.add_effect(counter_effect)
+
+      expect(wood_elves.counters.of_type(Magic::Counters::Plus1Plus1).count).to eq(4)
+    end
+  end
+end


### PR DESCRIPTION
This PR adds explicit chooser-driven replacement ordering, allowing players to choose the order in which replacement effects are applied when multiple effects would apply to the same event.

What changed:
- Updated 'lib/magic/game.rb' and 'lib/magic/player.rb' to handle choices.
- Introduced 'lib/magic/game/replacement_effect_resolver.rb' for logic.
- Added comprehensive integration tests in 'spec/game/integration/replacement_effect_choice_order_spec.rb'.

Documentation:
See 'docs/prs/pr-002-replacement-chooser-ordering.md' for more details.