### PR TITLE
PR 3: Replacement context and semantic applicability

### DIFF
--- a/docs/prs/pr-003-replacement-context-semantic-applicability.md
+++ b/docs/prs/pr-003-replacement-context-semantic-applicability.md
@@ -1,0 +1,67 @@
+# PR 3: Replacement context and semantic applicability
+
+## Summary
+This PR introduces a replacement context object and shifts replacement applicability matching away from exact class equality toward semantic base-class compatibility.
+
+The goal is to reduce coupling between replacement behavior and concrete Ruby effect class identity while preserving backward compatibility for existing cards.
+
+## Why
+Current replacement registration uses class-keyed mappings. Exact class matching is brittle and can miss valid replacements when effect subclasses or wrappers are used.
+
+This PR keeps current card APIs (`replacement_effects` hash) but makes matcher evaluation semantic (`is_a?`) and introduces a context object to carry affected-object metadata through replacement resolution.
+
+## What Changed
+1. Added replacement context object:
+- `lib/magic/game/replacement_effect_context.rb`
+- Carries current effect and applied replacement keys, plus derived affected target/player/controller helpers.
+
+2. Updated replacement resolver to use context:
+- `lib/magic/game/replacement_effect_resolver.rb`
+- Builds a context each iteration.
+- Chooses replacement with `replacement_context` available.
+- Applies replacement via `call_with_context`.
+
+3. Extended replacement base API with context-aware defaults:
+- `lib/magic/replacement_effect.rb`
+- Added `applies_with_context?(context)` defaulting to `applies?(context.effect)`.
+- Added `call_with_context(context)` defaulting to `call(context.effect)`.
+
+4. Reworked permanent replacement lookup:
+- `lib/magic/permanent.rb`
+- Iterates all declared replacement entries.
+- Uses semantic matcher behavior (`effect.is_a?(ClassMatcher)`).
+- Maintains applied-key guardrails.
+
+5. Propagated optional context to chooser interfaces:
+- `lib/magic/game.rb`
+- `lib/magic/player.rb`
+- Chooser methods now accept optional `replacement_context:` while remaining deterministic by default.
+
+## Behavior Notes
+- Existing replacement cards continue to work unchanged.
+- Replacement mapping is now robust to subclassed effect instances for class matchers.
+- Chooser resolution remains deterministic unless overridden.
+
+## Files Included In This PR
+- `lib/magic/replacement_effect.rb`
+- `lib/magic/game/replacement_effect_context.rb`
+- `lib/magic/game/replacement_effect_resolver.rb`
+- `lib/magic/permanent.rb`
+- `lib/magic/game.rb`
+- `lib/magic/player.rb`
+- `spec/game/integration/replacement_effect_semantic_applicability_spec.rb`
+
+## Test Evidence
+Targeted:
+- `bundle exec rspec spec/game/integration/replacement_effect_semantic_applicability_spec.rb spec/game/integration/replacement_effect_choice_order_spec.rb spec/cards/doubling_season_spec.rb spec/cards/conclave_mentor_spec.rb spec/cards/nine_lives_spec.rb`
+- Result: passing
+
+Full suite:
+- `bundle exec rspec`
+- Result: 524 examples, 0 failures
+
+## Follow-up
+Potential next steps:
+- Introduce richer matcher forms (predicate/lambda or explicit matcher objects).
+- Expand replacement source registry beyond battlefield-only scanning.
+- Add structured replacement trace metadata for debugging complex chains.

--- a/lib/magic/game.rb
+++ b/lib/magic/game.rb
@@ -103,10 +103,14 @@ module Magic
       effect.resolve!
     end
 
-    def choose_replacement_effect(effect:, replacement_effects:)
-      chooser = replacement_effect_chooser_for(effect)
+    def choose_replacement_effect(effect:, replacement_effects:, replacement_context: nil)
+      chooser = replacement_effect_chooser_for(effect, replacement_context)
       if chooser
-        chooser.choose_replacement_effect(effect: effect, replacement_effects: replacement_effects)
+        chooser.choose_replacement_effect(
+          effect: effect,
+          replacement_context: replacement_context,
+          replacement_effects: replacement_effects,
+        )
       else
         replacement_effects.first
       end
@@ -138,7 +142,11 @@ module Magic
 
     private
 
-    def replacement_effect_chooser_for(effect)
+    def replacement_effect_chooser_for(effect, replacement_context = nil)
+      if replacement_context&.affected_controller
+        return replacement_context.affected_controller
+      end
+
       if effect.respond_to?(:target)
         target = effect.target
         return target if target.respond_to?(:player?) && target.player?

--- a/lib/magic/game/replacement_effect_context.rb
+++ b/lib/magic/game/replacement_effect_context.rb
@@ -1,0 +1,40 @@
+module Magic
+  class Game
+    class ReplacementEffectContext
+      attr_reader :effect, :applied_replacement_keys
+
+      def initialize(effect:, applied_replacement_keys: [])
+        @effect = effect
+        @applied_replacement_keys = applied_replacement_keys
+      end
+
+      def affected_target
+        effect.target if effect.respond_to?(:target)
+      end
+
+      def affected_player
+        target = affected_target
+        return target if target.respond_to?(:player?) && target.player?
+
+        nil
+      end
+
+      def affected_permanent
+        target = affected_target
+        return target if target.respond_to?(:controller)
+
+        effect.permanent if effect.respond_to?(:permanent)
+      end
+
+      def affected_controller
+        if affected_player
+          affected_player
+        elsif affected_permanent&.respond_to?(:controller)
+          affected_permanent.controller
+        elsif effect.respond_to?(:controller)
+          effect.controller
+        end
+      end
+    end
+  end
+end

--- a/lib/magic/game/replacement_effect_resolver.rb
+++ b/lib/magic/game/replacement_effect_resolver.rb
@@ -10,19 +10,24 @@ module Magic
         applied_replacement_keys = []
 
         loop do
-          replacement_effects = applicable_replacement_effects(
+          context = ReplacementEffectContext.new(
             effect: current_effect,
             applied_replacement_keys: applied_replacement_keys,
+          )
+
+          replacement_effects = applicable_replacement_effects(
+            context: context,
           )
           break if replacement_effects.empty?
 
           replacement_effect = game.choose_replacement_effect(
-            effect: current_effect,
+            effect: context.effect,
+            replacement_context: context,
             replacement_effects: replacement_effects,
           )
           break unless replacement_effect
 
-          new_effect = replacement_effect.call(current_effect)
+          new_effect = replacement_effect.call_with_context(context)
           logger.debug "EFFECT REPLACED!"
           logger.debug "  Original: #{current_effect}"
           logger.debug "  Replacer: #{replacement_effect}"
@@ -47,11 +52,10 @@ module Magic
         game.battlefield
       end
 
-      def applicable_replacement_effects(effect:, applied_replacement_keys:)
+      def applicable_replacement_effects(context:)
         battlefield.filter_map do |permanent|
           permanent.replacement_effect_for(
-            effect,
-            applied_replacement_keys: applied_replacement_keys,
+            context,
           )
         end
       end

--- a/lib/magic/permanent.rb
+++ b/lib/magic/permanent.rb
@@ -155,14 +155,28 @@ module Magic
       @zone = new_zone.battlefield? ? new_zone : nil
     end
 
-    def replacement_effect_for(effect, applied_replacement_keys: [])
-      replacement_effect = card.replacement_effects[effect.class]
-      if replacement_effect
+    def replacement_effect_for(context)
+      card.replacement_effects.each do |matcher, replacement_effect|
+        next unless replacement_matcher_applies?(matcher, context.effect)
+
         replacement_key = [object_id, replacement_effect]
-        return if applied_replacement_keys.include?(replacement_key)
+        next if context.applied_replacement_keys.include?(replacement_key)
 
         replacement = replacement_effect.new(receiver: self)
-        replacement if replacement.applies?(effect)
+        return replacement if replacement.applies_with_context?(context)
+      end
+
+      nil
+    end
+
+    def replacement_matcher_applies?(matcher, effect)
+      case matcher
+      when nil
+        true
+      when Class
+        effect.is_a?(matcher)
+      else
+        matcher == effect.class
       end
     end
 

--- a/lib/magic/player.rb
+++ b/lib/magic/player.rb
@@ -287,7 +287,7 @@ module Magic
       end
     end
 
-    def choose_replacement_effect(effect:, replacement_effects:)
+    def choose_replacement_effect(effect:, replacement_effects:, replacement_context: nil)
       replacement_effects.first
     end
 

--- a/lib/magic/replacement_effect.rb
+++ b/lib/magic/replacement_effect.rb
@@ -10,8 +10,16 @@ module Magic
       raise NotImplemented
     end
 
+    def applies_with_context?(context)
+      applies?(context.effect)
+    end
+
     def call
       raise NotImplemented
+    end
+
+    def call_with_context(context)
+      call(context.effect)
     end
   end
 end

--- a/spec/game/integration/replacement_effect_semantic_applicability_spec.rb
+++ b/spec/game/integration/replacement_effect_semantic_applicability_spec.rb
@@ -1,0 +1,43 @@
+require 'spec_helper'
+
+RSpec.describe Magic::Game, "replacement effects -- semantic applicability" do
+  include_context "two player game"
+
+  let!(:wood_elves) { ResolvePermanent("Wood Elves", owner: p1) }
+
+  context "with a subclassed add-counter effect" do
+    let(:subclassed_counter_effect) do
+      Class.new(Magic::Effects::AddCounterToPermanent)
+    end
+
+    it "matches doubling season replacement by base class semantics" do
+      ResolvePermanent("Doubling Season", owner: p1)
+
+      effect = subclassed_counter_effect.new(
+        source: wood_elves,
+        counter_type: Magic::Counters::Plus1Plus1,
+        target: wood_elves,
+        amount: 1,
+      )
+
+      game.add_effect(effect)
+
+      expect(wood_elves.counters.of_type(Magic::Counters::Plus1Plus1).count).to eq(2)
+    end
+
+    it "matches conclave mentor replacement by base class semantics" do
+      ResolvePermanent("Conclave Mentor", owner: p1)
+
+      effect = subclassed_counter_effect.new(
+        source: wood_elves,
+        counter_type: Magic::Counters::Plus1Plus1,
+        target: wood_elves,
+        amount: 1,
+      )
+
+      game.add_effect(effect)
+
+      expect(wood_elves.counters.of_type(Magic::Counters::Plus1Plus1).count).to eq(2)
+    end
+  end
+end


### PR DESCRIPTION
## Summary
This PR shifts replacement effect applicability matching from exact class equality to semantic compatibility, using a new context object. 
Reference: [docs/prs/pr-003-replacement-context-semantic-applicability.md](docs/prs/pr-003-replacement-context-semantic-applicability.md)

## Files
- lib/magic/replacement_effect.rb
- lib/magic/game/replacement_effect_context.rb
- lib/magic/game/replacement_effect_resolver.rb
- lib/magic/permanent.rb
- lib/magic/game.rb
- lib/magic/player.rb

## Tests
- bundle exec rspec spec/game/integration/replacement_effect_semantic_applicability_spec.rb spec/game/integration/replacement_effect_choice_order_spec.rb spec/cards/doubling_season_spec.rb spec/cards/conclave_mentor_spec.rb spec/cards/nine_lives_spec.rb
- bundle exec rspec