### PR TITLE
PR 6: Damage pipeline normalization

### DIFF
--- a/docs/prs/pr-006-damage-pipeline-normalization.md
+++ b/docs/prs/pr-006-damage-pipeline-normalization.md
@@ -1,0 +1,65 @@
+# PR 6: Damage pipeline normalization
+
+## Summary
+This PR normalizes damage event emission so both noncombat and combat damage produce canonical `Events::DamageDealt` records.
+
+Combat damage retains existing `Events::CombatDamageDealt` emission for compatibility, while gameplay logic and new triggers can rely on `Events::DamageDealt` with metadata.
+
+## Why
+Damage handling was inconsistent:
+- Noncombat damage applied life loss/damage but emitted no canonical damage event.
+- Combat damage emitted a combat-only event.
+
+This made downstream trigger logic and telemetry inconsistent.
+
+## What Changed
+1. Expanded canonical damage event metadata:
+- `lib/magic/events/damage_dealt.rb`
+- Added `combat` and `infect` fields plus predicate helpers.
+
+2. Emitted canonical event for noncombat damage:
+- `lib/magic/effects/deal_damage.rb`
+- Now notifies `Events::DamageDealt` after applying damage.
+
+3. Emitted canonical event for combat damage:
+- `lib/magic/effects/deal_combat_damage.rb`
+- Now notifies `Events::DamageDealt` with `combat: true` and infect metadata.
+- Existing `Events::CombatDamageDealt` notification is retained.
+
+4. Removed obsolete player-side DamageDealt life-loss reaction:
+- `lib/magic/player.rb`
+- Prevents potential double life loss now that DamageDealt is emitted broadly.
+
+5. Migrated Lathril trigger to canonical event:
+- `lib/magic/cards/lathril_blade_of_the_elves.rb`
+- Listens to `Events::DamageDealt` and filters to combat damage.
+
+6. Added normalization integration tests:
+- `spec/game/integration/damage_event_normalization_spec.rb`
+- Verifies noncombat and combat paths both emit canonical damage events with expected metadata and life changes.
+
+## Behavior Notes
+- Damage is still applied directly by damage effects.
+- `Events::DamageDealt` is now the canonical cross-path damage signal.
+- `Events::CombatDamageDealt` remains available for backward compatibility.
+
+## Files Included In This PR
+- `lib/magic/events/damage_dealt.rb`
+- `lib/magic/effects/deal_damage.rb`
+- `lib/magic/effects/deal_combat_damage.rb`
+- `lib/magic/player.rb`
+- `lib/magic/cards/lathril_blade_of_the_elves.rb`
+- `spec/game/integration/damage_event_normalization_spec.rb`
+
+## Test Evidence
+Targeted:
+- `bundle exec rspec spec/game/integration/damage_event_normalization_spec.rb spec/cards/lathril_blade_of_the_elves_spec.rb spec/cards/lightning_bolt_spec.rb spec/game/integration/combat/pack_leader_prevents_combat_damage_spec.rb`
+- Result: passing
+
+Full suite:
+- `bundle exec rspec`
+- Result: 530 examples, 0 failures
+
+## Follow-up
+- Move remaining combat-only consumers to canonical damage events.
+- Evaluate eventual deprecation path for `Events::CombatDamageDealt` once no direct consumers remain.

--- a/lib/magic/cards/lathril_blade_of_the_elves.rb
+++ b/lib/magic/cards/lathril_blade_of_the_elves.rb
@@ -33,7 +33,7 @@ module Magic
 
       class ElfSpawner < TriggeredAbility
         def should_perform?
-          event.target.player?
+          event.combat? && event.target.player?
         end
 
         def call
@@ -43,7 +43,7 @@ module Magic
 
       def event_handlers
         {
-          Events::CombatDamageDealt => ElfSpawner
+          Events::DamageDealt => ElfSpawner
         }
       end
     end

--- a/lib/magic/effects/deal_combat_damage.rb
+++ b/lib/magic/effects/deal_combat_damage.rb
@@ -38,6 +38,16 @@ module Magic
         target.take_damage(damage)
 
         game.notify!(
+          Events::DamageDealt.new(
+            source: source,
+            target: target,
+            damage: damage,
+            combat: true,
+            infect: source.has_keyword?(Magic::Keywords::INFECT),
+          )
+        )
+
+        game.notify!(
           Events::CombatDamageDealt.new(
             source: source,
             target: target,

--- a/lib/magic/effects/deal_damage.rb
+++ b/lib/magic/effects/deal_damage.rb
@@ -10,6 +10,15 @@ module Magic
 
       def resolve!
         target.take_damage(damage)
+
+        game.notify!(
+          Events::DamageDealt.new(
+            source: source,
+            target: target,
+            damage: damage,
+            combat: false,
+          )
+        )
       end
     end
   end

--- a/lib/magic/events/damage_dealt.rb
+++ b/lib/magic/events/damage_dealt.rb
@@ -1,16 +1,26 @@
 module Magic
   module Events
     class DamageDealt
-      attr_reader :source, :target, :damage
+      attr_reader :source, :target, :damage, :combat, :infect
 
-      def initialize(source:, target:, damage:)
+      def initialize(source:, target:, damage:, combat: false, infect: false)
         @source = source
         @target = target
         @damage = damage
+        @combat = combat
+        @infect = infect
+      end
+
+      def combat?
+        @combat
+      end
+
+      def infect?
+        @infect
       end
 
       def inspect
-        "#<Events::DamageDealt source: #{source}, target: #{target}, damage: #{damage}>"
+        "#<Events::DamageDealt source: #{source}, target: #{target}, damage: #{damage}, combat: #{combat?}, infect: #{infect?}>"
       end
     end
   end

--- a/lib/magic/player.rb
+++ b/lib/magic/player.rb
@@ -273,8 +273,6 @@ module Magic
         @life += event.life
       when Events::PlayerLoses
         lose!
-      when Events::DamageDealt
-        trigger_effect(:lose_life, life: event.damage, source: event.source)
       end
     end
 

--- a/spec/game/integration/damage_event_normalization_spec.rb
+++ b/spec/game/integration/damage_event_normalization_spec.rb
@@ -1,0 +1,53 @@
+require 'spec_helper'
+
+RSpec.describe Magic::Game, 'damage events -- normalized pipeline' do
+  include_context 'two player game'
+
+  let!(:attacker) { ResolvePermanent('Loxodon Wayfarer', owner: p1) }
+
+  def damage_events
+    current_turn.events.select { |event| event.is_a?(Magic::Events::DamageDealt) }
+  end
+
+  it 'emits canonical noncombat damage event and applies damage once' do
+    p2_starting_life = p2.life
+
+    p1.add_mana(red: 1)
+    shock = Card('Shock', owner: p1)
+    p1.hand.add(shock)
+
+    p1.cast(card: shock) do
+      _1.pay_mana(red: 1)
+      _1.targeting(p2)
+    end
+
+    game.stack.resolve!
+
+    event = damage_events.last
+    aggregate_failures do
+      expect(event).not_to be_nil
+      expect(event.combat?).to eq(false)
+      expect(event.damage).to eq(2)
+      expect(p2.life).to eq(p2_starting_life - 2)
+    end
+  end
+
+  it 'emits canonical combat damage event with combat metadata' do
+    p2_starting_life = p2.life
+
+    skip_to_combat!
+    current_turn.declare_attackers!
+    current_turn.declare_attacker(attacker, target: p2)
+    go_to_combat_damage!
+
+    combat_damage_events = damage_events.select(&:combat?)
+    event = combat_damage_events.last
+
+    aggregate_failures do
+      expect(event).not_to be_nil
+      expect(event.combat?).to eq(true)
+      expect(event.damage).to eq(attacker.power)
+      expect(p2.life).to eq(p2_starting_life - attacker.power)
+    end
+  end
+end


### PR DESCRIPTION
# PR 6: Damage pipeline normalization

## Summary
This PR normalizes damage event emission so both noncombat and combat damage produce canonical `Events::DamageDealt` records.

Combat damage retains existing `Events::CombatDamageDealt` emission for compatibility, while gameplay logic and new triggers can rely on `Events::DamageDealt` with metadata.

## Why
Damage handling was inconsistent:
- Noncombat damage applied life loss/damage but emitted no canonical damage event.
- Combat damage emitted a combat-only event.

This made downstream trigger logic and telemetry inconsistent.

## What Changed
1. Expanded canonical damage event metadata:
- `lib/magic/events/damage_dealt.rb`
- Added `combat` and `infect` fields plus predicate helpers.

2. Emitted canonical event for noncombat damage:
- `lib/magic/effects/deal_damage.rb`
- Now notifies `Events::DamageDealt` after applying damage.

3. Emitted canonical event for combat damage:
- `lib/magic/effects/deal_combat_damage.rb`
- Now notifies `Events::DamageDealt` with `combat: true` and infect metadata.
- Existing `Events::CombatDamageDealt` notification is retained.

4. Removed obsolete player-side DamageDealt life-loss reaction:
- `lib/magic/player.rb`
- Prevents potential double life loss now that DamageDealt is emitted broadly.

5. Migrated Lathril trigger to canonical event:
- `lib/magic/cards/lathril_blade_of_the_elves.rb`
- Listens to `Events::DamageDealt` and filters to combat damage.

6. Added normalization integration tests:
- `spec/game/integration/damage_event_normalization_spec.rb`
- Verifies noncombat and combat paths both emit canonical damage events with expected metadata and life changes.

## Behavior Notes
- Damage is still applied directly by damage effects.
- `Events::DamageDealt` is now the canonical cross-path damage signal.
- `Events::CombatDamageDealt` remains available for backward compatibility.

## Files Included In This PR
- `lib/magic/events/damage_dealt.rb`
- `lib/magic/effects/deal_damage.rb`
- `lib/magic/effects/deal_combat_damage.rb`
- `lib/magic/player.rb`
- `lib/magic/cards/lathril_blade_of_the_elves.rb`
- `spec/game/integration/damage_event_normalization_spec.rb`

## Test Evidence
Targeted:
- `bundle exec rspec spec/game/integration/damage_event_normalization_spec.rb spec/cards/lathril_blade_of_the_elves_spec.rb spec/cards/lightning_bolt_spec.rb spec/game/integration/combat/pack_leader_prevents_combat_damage_spec.rb`
- Result: passing

Full suite:
- `bundle exec rspec`
- Result: 530 examples, 0 failures

## Follow-up
- Move remaining combat-only consumers to canonical damage events.
- Evaluate eventual deprecation path for `Events::CombatDamageDealt` once no direct consumers remain.
