### PR TITLE
PR 7: Replacement contracts and tracing hardening

### DIFF
--- a/docs/prs/pr-007-replacement-contracts-and-tracing.md
+++ b/docs/prs/pr-007-replacement-contracts-and-tracing.md
@@ -1,0 +1,60 @@
+# PR 7: Replacement contracts and tracing hardening
+
+## Summary
+This PR tightens the `ReplacementEffect` contract and adds structured tracing around replacement candidate discovery and application.
+
+It improves diagnostics and guards against subtle contract violations when implementing new replacement effects.
+
+## Why
+Replacement behavior was functionally working, but contracts were implicit and logging was unstructured. That made failures harder to diagnose and made it easy to accidentally return invalid values from replacement hooks.
+
+## What Changed
+1. Hardened replacement contract surface:
+- `lib/magic/replacement_effect.rb`
+- `applies?` and `call` now raise `NotImplementedError` with explicit method expectations.
+- Added `InvalidApplicabilityResult` when `applies?` does not return boolean.
+- Added `InvalidReplacementResult` when `call` does not return an effect-like object responding to `resolve!`.
+
+2. Added structured tracing in resolver:
+- `lib/magic/game/replacement_effect_resolver.rb`
+- Logs candidate sets, selected replacement, and applied result payloads with stable labels:
+  - `REPLACEMENT_CANDIDATES`
+  - `REPLACEMENT_SELECTED`
+  - `REPLACEMENT_APPLIED`
+
+3. Hardened replacement context derivation:
+- `lib/magic/game/replacement_effect_context.rb`
+- Safer target/controller derivation to avoid nil/NoMethodError edge cases during chooser tracing.
+
+4. Added contract tests:
+- `spec/replacement_effect_spec.rb`
+- Verifies base interface raises `NotImplementedError`.
+- Verifies validation errors for invalid `applies?` and invalid `call` return values.
+
+## Behavior Notes
+- Existing replacement cards continue to work.
+- Contract violations now fail fast with descriptive errors.
+- Replacement traces are easier to follow in debug logs.
+
+## Files Included In This PR
+- `lib/magic/replacement_effect.rb`
+- `lib/magic/game/replacement_effect_resolver.rb`
+- `lib/magic/game/replacement_effect_context.rb`
+- `spec/replacement_effect_spec.rb`
+
+## Test Evidence
+Targeted:
+- `bundle exec rspec spec/replacement_effect_spec.rb spec/game/integration/replacement_effect_choice_order_spec.rb spec/game/integration/replacement_effect_semantic_applicability_spec.rb spec/game/integration/replacement_effect_source_eligibility_spec.rb`
+- Result: passing
+
+Regression re-check after context safety fixes:
+- `bundle exec rspec spec/game/integration/combat/nine_lives_damage_prevented_spec.rb spec/replacement_effect_spec.rb`
+- Result: passing
+
+Full suite:
+- `bundle exec rspec`
+- Result: 534 examples, 0 failures
+
+## Follow-up
+- Consider serializing replacement trace payloads in a machine-parsable format for tooling.
+- Add optional trace IDs to correlate replacement chains across nested effect resolution.

--- a/lib/magic/game/replacement_effect_context.rb
+++ b/lib/magic/game/replacement_effect_context.rb
@@ -9,7 +9,12 @@ module Magic
       end
 
       def affected_target
-        effect.target if effect.respond_to?(:target)
+        if effect.respond_to?(:targets)
+          targets = effect.targets || []
+          return targets.first if targets.count == 1
+        end
+
+        nil
       end
 
       def affected_player
@@ -31,8 +36,8 @@ module Magic
           affected_player
         elsif affected_permanent&.respond_to?(:controller)
           affected_permanent.controller
-        elsif effect.respond_to?(:controller)
-          effect.controller
+        elsif effect.respond_to?(:source) && effect.source.respond_to?(:controller)
+          effect.source.controller
         end
       end
     end

--- a/lib/magic/game/replacement_effect_resolver.rb
+++ b/lib/magic/game/replacement_effect_resolver.rb
@@ -18,6 +18,7 @@ module Magic
           replacement_effects = applicable_replacement_effects(
             context: context,
           )
+          log_candidates(context: context, replacement_effects: replacement_effects)
           break if replacement_effects.empty?
 
           replacement_effect = game.choose_replacement_effect(
@@ -25,13 +26,15 @@ module Magic
             replacement_context: context,
             replacement_effects: replacement_effects,
           )
+          log_selected_replacement(context: context, replacement_effect: replacement_effect)
           break unless replacement_effect
 
           new_effect = replacement_effect.call_with_context(context)
-          logger.debug "EFFECT REPLACED!"
-          logger.debug "  Original: #{current_effect}"
-          logger.debug "  Replacer: #{replacement_effect}"
-          logger.debug "  New Effect: #{new_effect}"
+          log_application(
+            original_effect: current_effect,
+            replacement_effect: replacement_effect,
+            new_effect: new_effect,
+          )
 
           applied_replacement_keys << replacement_key_for(replacement_effect)
           current_effect = new_effect
@@ -58,6 +61,36 @@ module Magic
 
       def replacement_key_for(replacement_effect)
         [replacement_effect.receiver.object_id, replacement_effect.class]
+      end
+
+      def replacement_effect_identifier(replacement_effect)
+        "#{replacement_effect.class}(receiver=#{replacement_effect.receiver})"
+      end
+
+      def log_candidates(context:, replacement_effects:)
+        payload = {
+          effect: context.effect.class.name,
+          affected_controller: context.affected_controller,
+          candidates: replacement_effects.map { replacement_effect_identifier(_1) },
+        }
+        logger.debug "REPLACEMENT_CANDIDATES: #{payload.inspect}"
+      end
+
+      def log_selected_replacement(context:, replacement_effect:)
+        payload = {
+          effect: context.effect.class.name,
+          selected: replacement_effect && replacement_effect_identifier(replacement_effect),
+        }
+        logger.debug "REPLACEMENT_SELECTED: #{payload.inspect}"
+      end
+
+      def log_application(original_effect:, replacement_effect:, new_effect:)
+        payload = {
+          original: original_effect.class.name,
+          replacement: replacement_effect_identifier(replacement_effect),
+          result: new_effect.class.name,
+        }
+        logger.debug "REPLACEMENT_APPLIED: #{payload.inspect}"
       end
     end
   end

--- a/lib/magic/replacement_effect.rb
+++ b/lib/magic/replacement_effect.rb
@@ -1,25 +1,38 @@
 module Magic
   class ReplacementEffect
+    class InvalidApplicabilityResult < StandardError; end
+    class InvalidReplacementResult < StandardError; end
+
     attr_reader :receiver
 
     def initialize(receiver:)
       @receiver = receiver
     end
 
-    def applies?
-      raise NotImplemented
+    def applies?(_effect)
+      raise NotImplementedError, "#{self.class} must implement #applies?(effect)"
     end
 
     def applies_with_context?(context)
-      applies?(context.effect)
+      result = applies?(context.effect)
+      unless result == true || result == false
+        raise InvalidApplicabilityResult, "#{self.class}#applies? must return true or false"
+      end
+
+      result
     end
 
-    def call
-      raise NotImplemented
+    def call(_effect)
+      raise NotImplementedError, "#{self.class} must implement #call(effect)"
     end
 
     def call_with_context(context)
-      call(context.effect)
+      replacement_effect = call(context.effect)
+      unless replacement_effect.respond_to?(:resolve!)
+        raise InvalidReplacementResult, "#{self.class}#call must return an effect-like object responding to #resolve!"
+      end
+
+      replacement_effect
     end
   end
 end

--- a/spec/replacement_effect_spec.rb
+++ b/spec/replacement_effect_spec.rb
@@ -1,0 +1,65 @@
+require 'spec_helper'
+
+RSpec.describe Magic::ReplacementEffect do
+  DummyContext = Struct.new(:effect)
+
+  let(:context) { DummyContext.new(Object.new) }
+
+  describe '#applies_with_context?' do
+    it 'raises when applies? does not return a boolean' do
+      klass = Class.new(described_class) do
+        def applies?(_effect)
+          :maybe
+        end
+
+        def call(effect)
+          effect
+        end
+      end
+
+      replacement = klass.new(receiver: Object.new)
+
+      expect {
+        replacement.applies_with_context?(context)
+      }.to raise_error(Magic::ReplacementEffect::InvalidApplicabilityResult)
+    end
+  end
+
+  describe '#call_with_context' do
+    it 'raises when call does not return an effect-like object' do
+      klass = Class.new(described_class) do
+        def applies?(_effect)
+          true
+        end
+
+        def call(_effect)
+          Object.new
+        end
+      end
+
+      replacement = klass.new(receiver: Object.new)
+
+      expect {
+        replacement.call_with_context(context)
+      }.to raise_error(Magic::ReplacementEffect::InvalidReplacementResult)
+    end
+  end
+
+  describe 'base interface' do
+    it 'raises NotImplementedError for applies?' do
+      replacement = described_class.new(receiver: Object.new)
+
+      expect {
+        replacement.applies?(Object.new)
+      }.to raise_error(NotImplementedError)
+    end
+
+    it 'raises NotImplementedError for call' do
+      replacement = described_class.new(receiver: Object.new)
+
+      expect {
+        replacement.call(Object.new)
+      }.to raise_error(NotImplementedError)
+    end
+  end
+end


### PR DESCRIPTION
# PR 7: Replacement contracts and tracing hardening

## Summary
This PR tightens the `ReplacementEffect` contract and adds structured tracing around replacement candidate discovery and application.

It improves diagnostics and guards against subtle contract violations when implementing new replacement effects.

## Why
Replacement behavior was functionally working, but contracts were implicit and logging was unstructured. That made failures harder to diagnose and made it easy to accidentally return invalid values from replacement hooks.

## What Changed
1. Hardened replacement contract surface:
- `lib/magic/replacement_effect.rb`
- `applies?` and `call` now raise `NotImplementedError` with explicit method expectations.
- Added `InvalidApplicabilityResult` when `applies?` does not return boolean.
- Added `InvalidReplacementResult` when `call` does not return an effect-like object responding to `resolve!`.

2. Added structured tracing in resolver:
- `lib/magic/game/replacement_effect_resolver.rb`
- Logs candidate sets, selected replacement, and applied result payloads with stable labels:
  - `REPLACEMENT_CANDIDATES`
  - `REPLACEMENT_SELECTED`
  - `REPLACEMENT_APPLIED`

3. Hardened replacement context derivation:
- `lib/magic/game/replacement_effect_context.rb`
- Safer target/controller derivation to avoid nil/NoMethodError edge cases during chooser tracing.

4. Added contract tests:
- `spec/replacement_effect_spec.rb`
- Verifies base interface raises `NotImplementedError`.
- Verifies validation errors for invalid `applies?` and invalid `call` return values.

## Behavior Notes
- Existing replacement cards continue to work.
- Contract violations now fail fast with descriptive errors.
- Replacement traces are easier to follow in debug logs.

## Files Included In This PR
- `lib/magic/replacement_effect.rb`
- `lib/magic/game/replacement_effect_resolver.rb`
- `lib/magic/game/replacement_effect_context.rb`
- `spec/replacement_effect_spec.rb`

## Test Evidence
Targeted:
- `bundle exec rspec spec/replacement_effect_spec.rb spec/game/integration/replacement_effect_choice_order_spec.rb spec/game/integration/replacement_effect_semantic_applicability_spec.rb spec/game/integration/replacement_effect_source_eligibility_spec.rb`
- Result: passing

Regression re-check after context safety fixes:
- `bundle exec rspec spec/game/integration/combat/nine_lives_damage_prevented_spec.rb spec/replacement_effect_spec.rb`
- Result: passing

Full suite:
- `bundle exec rspec`
- Result: 534 examples, 0 failures

## Follow-up
- Consider serializing replacement trace payloads in a machine-parsable format for tooling.
- Add optional trace IDs to correlate replacement chains across nested effect resolution.
