### PR TITLE
Implement Sanctum of All

### DIFF
--- a/lib/magic/card_list.rb
+++ b/lib/magic/card_list.rb
@@ -16,6 +16,10 @@ module Magic
       select(&:basic_land?)
     end
 
+    def shrines
+      by_any_type("Shrine")
+    end
+
     def creatures
        select(&:creature?)
     end

--- a/lib/magic/cards/sanctum_of_all.rb
+++ b/lib/magic/cards/sanctum_of_all.rb
@@ -1,0 +1,89 @@
+module Magic
+  module Cards
+    SanctumOfAll = Enchantment("Sanctum of All") do
+      type T::Super::Legendary, T::Enchantment, "Shrine"
+      cost white: 1, blue: 1, black: 1, red: 1, green: 1
+
+      class UpkeepTrigger < TriggeredAbility::BeginningOfYourUpkeep
+        def call
+          game.add_choice(SanctumOfAll::MaySearchChoice.new(actor: actor))
+        end
+      end
+
+      class AdditionalTriggerHandler < TriggeredAbility
+        def should_perform?
+          controller.permanents.by_type("Shrine").count >= 6 &&
+            other_shrine_handlers_for(event.class).any?
+        end
+
+        def call
+          other_shrine_handlers_for(event.class).each do |shrine_perm, handler_class|
+            handler_class.new(actor: shrine_perm, event: event).perform!
+          end
+        end
+
+        private
+
+        def other_shrine_handlers_for(event_class)
+          controller.permanents.by_type("Shrine")
+            .reject { |p| p == actor }
+            .flat_map do |p|
+              Array(p.card.event_handlers[event_class])
+                .reject { |h| h <= AdditionalTriggerHandler }
+                .map { |h| [p, h] }
+            end
+        end
+      end
+
+      def event_handlers
+        base = { Events::BeginningOfUpkeep => [UpkeepTrigger, AdditionalTriggerHandler] }
+        Hash.new { |_, _| [AdditionalTriggerHandler] }.merge(base)
+      end
+    end
+
+    class SanctumOfAll < Enchantment
+      class MaySearchChoice < Magic::Choice::May
+        def resolve!
+          game.add_choice(SanctumOfAll::GraveyardSearchMayChoice.new(actor: actor))
+          game.add_choice(SanctumOfAll::LibrarySearchMayChoice.new(actor: actor))
+        end
+      end
+
+      class LibrarySearchMayChoice < Magic::Choice::May
+        def resolve!
+          game.add_choice(SanctumOfAll::LibrarySearchChoice.new(actor: actor))
+        end
+      end
+
+      class LibrarySearchChoice < Magic::Choice::SearchLibrary
+        def initialize(actor:)
+          super(
+            actor: actor,
+            to_zone: :battlefield,
+            filter: Filter[:shrines]
+          )
+        end
+      end
+
+      class GraveyardSearchMayChoice < Magic::Choice::May
+        def resolve!
+          game.add_choice(SanctumOfAll::GraveyardSearchChoice.new(actor: actor))
+        end
+      end
+
+      class GraveyardSearchChoice < Magic::Choice::SearchGraveyard
+        def choices
+          controller.graveyard.cards.by_type("Shrine")
+        end
+
+        def choice_amount
+          1
+        end
+
+        def resolve!(target:)
+          target.resolve!
+        end
+      end
+    end
+  end
+end

--- a/spec/cards/sanctum_of_all_spec.rb
+++ b/spec/cards/sanctum_of_all_spec.rb
@@ -1,0 +1,122 @@
+# frozen_string_literal: true
+
+require "spec_helper"
+
+RSpec.describe Magic::Cards::SanctumOfAll do
+  include_context "two player game"
+
+  let!(:sanctum_of_all) { ResolvePermanent("Sanctum Of All") }
+
+  it "is a legendary enchantment shrine" do
+    expect(sanctum_of_all).to be_legendary
+    expect(sanctum_of_all).to be_enchantment
+    expect(sanctum_of_all.types).to include("Shrine")
+  end
+
+  context "at the beginning of your upkeep" do
+    it "presents a may choice to search" do
+      current_turn.untap!
+      current_turn.upkeep!
+
+      expect(game.choices.first).to be_a(described_class::MaySearchChoice)
+    end
+
+    context "when the player searches their library" do
+      let(:shrine_in_library) { add_to_library("Sanctum Of Tranquil Light", player: p1) }
+
+      before do
+        shrine_in_library
+        current_turn.untap!
+        current_turn.upkeep!
+      end
+
+      it "can search library for a shrine and put it onto the battlefield" do
+        game.resolve_choice! # resolve MaySearchChoice
+
+        expect(game.choices.first).to be_a(described_class::LibrarySearchMayChoice)
+        game.resolve_choice! # resolve LibrarySearchMayChoice
+
+        expect(game.choices.first).to be_a(described_class::LibrarySearchChoice)
+        game.resolve_choice!(target: shrine_in_library)
+
+        expect(p1.permanents.by_type("Shrine").count).to eq(2)
+      end
+
+      it "can skip the library search" do
+        game.resolve_choice! # resolve MaySearchChoice
+
+        expect(game.choices.first).to be_a(described_class::LibrarySearchMayChoice)
+        game.skip_choice! # skip LibrarySearchMayChoice
+
+        expect(p1.permanents.by_type("Shrine").count).to eq(1)
+      end
+    end
+
+    context "when the player searches their graveyard" do
+      let!(:shrine_in_graveyard) do
+        card = Card("Sanctum Of Tranquil Light", owner: p1)
+        card.zone = p1.graveyard
+        p1.graveyard.items << card
+        card
+      end
+
+      before do
+        current_turn.untap!
+        current_turn.upkeep!
+      end
+
+      it "can search graveyard for a shrine and put it onto the battlefield" do
+        game.resolve_choice! # resolve MaySearchChoice
+
+        game.skip_choice! # skip LibrarySearchMayChoice
+
+        expect(game.choices.first).to be_a(described_class::GraveyardSearchMayChoice)
+        game.resolve_choice! # resolve GraveyardSearchMayChoice -> auto-resolves GraveyardSearchChoice (single target)
+
+        expect(p1.permanents.by_type("Shrine").count).to eq(2)
+      end
+    end
+
+    it "can skip the entire search" do
+      current_turn.untap!
+      current_turn.upkeep!
+
+      game.skip_choice! # skip MaySearchChoice
+
+      expect(p1.permanents.by_type("Shrine").count).to eq(1)
+    end
+  end
+
+  context "additional trigger with six or more shrines" do
+    let!(:calm_waters_1) { ResolvePermanent("Sanctum Of Calm Waters") }
+    let!(:calm_waters_2) { ResolvePermanent("Sanctum Of Calm Waters") }
+    let!(:calm_waters_3) { ResolvePermanent("Sanctum Of Calm Waters") }
+    let!(:calm_waters_4) { ResolvePermanent("Sanctum Of Calm Waters") }
+    let!(:calm_waters_5) { ResolvePermanent("Sanctum Of Calm Waters") }
+
+    it "triggers other shrine abilities an additional time when controlling six or more shrines" do
+      go_to_main_phase!
+
+      # SanctumOfCalmWaters triggers on FirstMainPhase
+      # With Sanctum of All + 5x SanctumOfCalmWaters = 6 shrines
+      # Each calm waters triggers once normally, then Sanctum of All doubles it
+      # So each calm waters triggers twice, giving 5 * 2 = 10 FirstMainPhase choices
+      # Plus Sanctum of All's own upkeep choice was already resolved
+      calm_waters_choices = game.choices.select { |c| c.is_a?(Magic::Cards::SanctumOfCalmWaters::Choice) }
+      expect(calm_waters_choices.count).to eq(10)
+    end
+
+    context "with fewer than six shrines" do
+      it "does not trigger additional times with only five shrines" do
+        # Remove calm_waters_5 from play (we have 5 total: sanctum_of_all + 4 calm_waters)
+        calm_waters_5.move_zone!(from: game.battlefield, to: calm_waters_5.controller.graveyard)
+
+        go_to_main_phase!
+
+        # With only 5 shrines, no doubling
+        calm_waters_choices = game.choices.select { |c| c.is_a?(Magic::Cards::SanctumOfCalmWaters::Choice) }
+        expect(calm_waters_choices.count).to eq(4)
+      end
+    end
+  end
+end


### PR DESCRIPTION
## Summary

- Adds `Sanctum of All` ({W}{U}{B}{R}{G}, Legendary Enchantment — Shrine), resolving issue #236
- Upkeep trigger presents optional library and/or graveyard searches for Shrine cards to put onto the battlefield (with shuffle when searching the library)
- "Triggers an additional time" mechanic: when 6+ Shrines are controlled, other Shrine triggered abilities fire a second time, implemented via a `Hash` default proc on `event_handlers` that dispatches `AdditionalTriggerHandler` for every game event
- Adds `CardList#shrines` to support `Filter[:shrines]` in the library search

## Test plan

- [x] `bundle exec rspec spec/cards/sanctum_of_all_spec.rb` — 8 examples covering card type, upkeep trigger, library search, graveyard search, skip paths, and the 6-shrine additional trigger
- [ ] `bundle exec rspec` — full suite (545 examples) passes

🤖 Generated with [Claude Code](https://claude.com/claude-code)