### PR TITLE
Add FirstMainPhaseTrigger to Saga for automatic lore counter progression

### DIFF
--- a/lib/magic/cards/saga.rb
+++ b/lib/magic/cards/saga.rb
@@ -18,11 +18,17 @@ module Magic
         actor.trigger_effect(:add_counter, counter_type: Magic::Counters::Lore, target: actor)
       end
 
-      class CounterAdded < TriggeredAbility::LoreCounterAdded
+      class FirstMainPhaseTrigger < TriggeredAbility
         def should_perform?
-          super
+          event.active_player == controller
         end
 
+        def call
+          actor.trigger_effect(:add_counter, counter_type: Magic::Counters::Lore, target: actor)
+        end
+      end
+
+      class CounterAdded < TriggeredAbility::LoreCounterAdded
         def call
           lore_counters = actor.counters.of_type(Magic::Counters::Lore).count
 
@@ -40,6 +46,7 @@ module Magic
 
       def event_handlers
         {
+          Events::FirstMainPhase => FirstMainPhaseTrigger,
           Events::CounterAddedToPermanent => CounterAdded
         }
       end

--- a/spec/cards/battle_for_bretagard_spec.rb
+++ b/spec/cards/battle_for_bretagard_spec.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 require 'spec_helper'
 
 RSpec.describe Magic::Cards::BattleForBretagard do
@@ -7,19 +9,18 @@ RSpec.describe Magic::Cards::BattleForBretagard do
 
   before do
     p1.hand.add(card)
-  end
-
-  it "gets a counter + creates a human warrior when it is cast" do
+    go_to_main_phase!
     p1.add_mana(white: 1, green: 2)
-
     p1.cast(card: card) do
       _1.pay_mana(white: 1, green: 1, generic: { green: 1 })
     end
-
     game.stack.resolve!
     game.tick!
+  end
 
-    battle_for_bretagard = game.battlefield.by_name("Battle for Bretagard").first
+  let(:battle_for_bretagard) { game.battlefield.by_name("Battle for Bretagard").first }
+
+  it "enters with a lore counter and triggers Chapter 1 (creates a Human Warrior token)" do
     expect(battle_for_bretagard.counters.of_type(Magic::Counters::Lore).count).to eq(1)
 
     human_warrior = game.battlefield.creatures.by_name("Human Warrior").first
@@ -27,26 +28,45 @@ RSpec.describe Magic::Cards::BattleForBretagard do
     expect(human_warrior.power).to eq(1)
     expect(human_warrior.toughness).to eq(1)
     expect(human_warrior.colors).to eq([:white])
+  end
 
-    battle_for_bretagard.trigger_effect(:add_counter, counter_type: Magic::Counters::Lore, target: battle_for_bretagard)
+  context "on the second turn" do
+    before do
+      2.times { game.next_turn }
+      go_to_main_phase!
+      game.stack.resolve!
+      game.tick!
+    end
 
-    game.stack.resolve!
-    game.tick!
+    it "triggers Chapter 2 (creates an Elf Warrior token)" do
+      expect(battle_for_bretagard.counters.of_type(Magic::Counters::Lore).count).to eq(2)
 
-    elf_warrior = game.battlefield.creatures.by_name("Elf Warrior").first
-    expect(elf_warrior).to_not be_nil
-    expect(elf_warrior.power).to eq(1)
-    expect(elf_warrior.toughness).to eq(1)
-    expect(elf_warrior.colors).to eq([:green])
+      elf_warrior = game.battlefield.creatures.by_name("Elf Warrior").first
+      expect(elf_warrior).to_not be_nil
+      expect(elf_warrior.power).to eq(1)
+      expect(elf_warrior.toughness).to eq(1)
+      expect(elf_warrior.colors).to eq([:green])
+    end
 
-    battle_for_bretagard.trigger_effect(:add_counter, counter_type: Magic::Counters::Lore, target: battle_for_bretagard)
+    context "on the third turn" do
+      let!(:saga_card) { battle_for_bretagard.card }
 
-    game.stack.resolve!
-    game.tick!
+      before do
+        2.times { game.next_turn }
+        go_to_main_phase!
+        game.stack.resolve!
+        game.tick!
+      end
 
-    expect(human_warrior).to have_keyword(:deathtouch)
-    expect(elf_warrior).to have_keyword(:deathtouch)
+      it "triggers Chapter 3 (grants deathtouch to all creatures) and sacrifices itself" do
+        human_warrior = game.battlefield.creatures.by_name("Human Warrior").first
+        elf_warrior = game.battlefield.creatures.by_name("Elf Warrior").first
 
-    expect(battle_for_bretagard.card.zone).to be_graveyard
+        expect(human_warrior).to have_keyword(:deathtouch)
+        expect(elf_warrior).to have_keyword(:deathtouch)
+
+        expect(saga_card.zone).to be_graveyard
+      end
+    end
   end
 end


### PR DESCRIPTION
## Summary

- Added `FirstMainPhaseTrigger` inner class to `Saga` that fires on `Events::FirstMainPhase` and adds a lore counter when it's the controller's main phase
- Removed the pointless `should_perform?` override in `CounterAdded` (it just called `super`)
- Rewrote `spec/cards/battle_for_bretagard_spec.rb` to use real turn progression (`game.next_turn` + `go_to_main_phase!`) instead of manually calling `trigger_effect(:add_counter, ...)` to simulate subsequent turns
- Split the single large test into three focused examples: one per Saga chapter

## Behaviour fixed

Previously, Sagas only added a lore counter on ETB (via `enters_the_battlefield`). Subsequent chapter abilities had to be triggered manually. Now, at the beginning of each of the controller's precombat main phases the Saga automatically adds a lore counter and fires the next chapter — matching MTG rule 714.3a.

## Test plan

- [x] `bundle exec rspec spec/cards/battle_for_bretagard_spec.rb` — all 3 examples pass
- [x] `bundle exec rspec` — all 536 examples pass, no regressions

🤖 Generated with [Claude Code](https://claude.com/claude-code)