### PR TITLE
Add Sanctum of Fruitful Harvest

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -46,6 +46,7 @@ This is a Magic: The Gathering simulation engine written in Ruby without UI. The
    - Base card types: `Creature`, `Instant`, `Sorcery`, `Enchantment`, `Aura`, `Saga`, `Artifact`, `Equipment`
    - Simple cards need only cost and creature stats (Example: `StorySeeker`)
    - Complex cards extend the base class with triggered abilities, activated abilities, and event handlers (Example: `AcademyElite`)
+   - **DSL block vs class reopening**: The DSL block (`Enchantment("Name") do ... end`) runs in the `Magic::Cards` lexical scope, so any `class Foo` defined inside it lands in `Magic::Cards::Foo` — not nested inside the card class. To avoid name collisions between cards, keep the DSL block to type and cost only, then define trigger classes, choice classes, and `event_handlers` in a class reopening (`class CardName < Enchantment; ...; end`). Constants defined there are properly scoped to the card. Example: `SanctumOfCalmWaters`, `SanctumOfFruitfulHarvest`.
 
 ### Events & Abilities
 

--- a/lib/magic/cards/sanctum_of_calm_waters.rb
+++ b/lib/magic/cards/sanctum_of_calm_waters.rb
@@ -3,7 +3,9 @@ module Magic
     SanctumOfCalmWaters = Enchantment("Sanctum of Calm Waters") do
       type T::Super::Legendary, T::Enchantment, "Shrine"
       cost generic: 3, blue: 1
+    end
 
+    class SanctumOfCalmWaters < Enchantment
       class FirstMainPhaseTrigger < TriggeredAbility
         def should_perform?
           event.active_player == controller
@@ -14,22 +16,19 @@ module Magic
         end
       end
 
-      def event_handlers
-        {
-          Events::FirstMainPhase => FirstMainPhaseTrigger
-        }
-      end
-    end
-
-    class SanctumOfCalmWaters < Enchantment
       class Choice < Magic::Choice
-
         def resolve!
           shrines = controller.permanents.by_type("Shrine").count
           actor.trigger_effect(:draw_cards, number_to_draw: shrines)
 
           actor.add_choice(:discard)
         end
+      end
+
+      def event_handlers
+        {
+          Events::FirstMainPhase => FirstMainPhaseTrigger
+        }
       end
     end
   end

--- a/lib/magic/cards/sanctum_of_fruitful_harvest.rb
+++ b/lib/magic/cards/sanctum_of_fruitful_harvest.rb
@@ -3,7 +3,9 @@ module Magic
     SanctumOfFruitfulHarvest = Enchantment("Sanctum of Fruitful Harvest") do
       type T::Super::Legendary, T::Enchantment, "Shrine"
       cost generic: 2, green: 1
+    end
 
+    class SanctumOfFruitfulHarvest < Enchantment
       class FirstMainPhaseTrigger < TriggeredAbility
         def should_perform?
           event.active_player == controller
@@ -14,19 +16,17 @@ module Magic
         end
       end
 
-      def event_handlers
-        {
-          Events::FirstMainPhase => FirstMainPhaseTrigger
-        }
-      end
-    end
-
-    class SanctumOfFruitfulHarvest < Enchantment
       class ColorChoice < Magic::Choice::Color
         def resolve!(color:)
           shrines = controller.permanents.by_type("Shrine").count
           controller.add_mana(color => shrines)
         end
+      end
+
+      def event_handlers
+        {
+          Events::FirstMainPhase => FirstMainPhaseTrigger
+        }
       end
     end
   end

--- a/lib/magic/cards/sanctum_of_fruitful_harvest.rb
+++ b/lib/magic/cards/sanctum_of_fruitful_harvest.rb
@@ -1,0 +1,33 @@
+module Magic
+  module Cards
+    SanctumOfFruitfulHarvest = Enchantment("Sanctum of Fruitful Harvest") do
+      type T::Super::Legendary, T::Enchantment, "Shrine"
+      cost generic: 2, green: 1
+
+      class FirstMainPhaseTrigger < TriggeredAbility
+        def should_perform?
+          event.active_player == controller
+        end
+
+        def call
+          game.choices.add(SanctumOfFruitfulHarvest::ColorChoice.new(actor: actor))
+        end
+      end
+
+      def event_handlers
+        {
+          Events::FirstMainPhase => FirstMainPhaseTrigger
+        }
+      end
+    end
+
+    class SanctumOfFruitfulHarvest < Enchantment
+      class ColorChoice < Magic::Choice::Color
+        def resolve!(color:)
+          shrines = controller.permanents.by_type("Shrine").count
+          controller.add_mana(color => shrines)
+        end
+      end
+    end
+  end
+end

--- a/spec/cards/sanctum_of_fruitful_harvest_spec.rb
+++ b/spec/cards/sanctum_of_fruitful_harvest_spec.rb
@@ -1,0 +1,22 @@
+# frozen_string_literal: true
+
+require 'spec_helper'
+
+RSpec.describe Magic::Cards::SanctumOfFruitfulHarvest do
+  include_context "two player game"
+
+  let!(:sanctum_of_tranquil_light) { ResolvePermanent("Sanctum Of Tranquil Light") }
+  let!(:sanctum_of_fruitful_harvest) { ResolvePermanent("Sanctum Of Fruitful Harvest") }
+
+  context "at beginning of precombat main phase" do
+    it "adds mana equal to the number of shrines in the chosen color" do
+      go_to_main_phase!
+
+      choice = game.choices.first
+      expect(choice).to be_a(described_class::ColorChoice)
+      game.resolve_choice!(color: :green)
+
+      expect(p1.mana_pool[:green]).to eq(2)
+    end
+  end
+end


### PR DESCRIPTION
## Summary

- Implements Sanctum of Fruitful Harvest (`{2}{G}`, Legendary Enchantment — Shrine)
- At the beginning of your first main phase, adds X mana of any one color, where X is the number of Shrines you control
- Uses `FirstMainPhaseTrigger` and `Magic::Choice::Color` pattern consistent with other shrine cards

## Test plan

- [x] Triggers at beginning of controller's first main phase
- [x] Prompts for color choice (`ColorChoice`)
- [x] Adds mana equal to the number of Shrines controlled in the chosen color

🤖 Generated with [Claude Code](https://claude.com/claude-code)