### PR TITLE
Replace delayed_response Procs with register_turn_trigger on Permanent

### DIFF
--- a/lib/magic/actions/activate_loyalty_ability.rb
+++ b/lib/magic/actions/activate_loyalty_ability.rb
@@ -40,6 +40,7 @@ module Magic
         end
 
         planeswalker.change_loyalty!(loyalty_change)
+        game.notify!(Events::AbilityActivated.new(ability: ability, player: player))
         game.stack.add(self)
       end
 

--- a/lib/magic/cards/basri_ket.rb
+++ b/lib/magic/cards/basri_ket.rb
@@ -41,23 +41,22 @@ module Magic
         end
       end
 
+      class SoldierTokensTrigger < TriggeredAbility
+        def call
+          attackers = game.current_turn.attacks.count
+
+          attackers.times do
+            token = trigger_effect(:create_token, token_class: SoldierToken, enters_tapped: true).first
+            game.current_turn.declare_attacker(token)
+          end
+        end
+      end
+
       class LoyaltyAbility2 < Magic::LoyaltyAbility
         def loyalty_change = -2
 
         def resolve!
-          source.delayed_response(
-            turn: game.current_turn,
-            event_type: Events::PreliminaryAttackersDeclared,
-            response: -> {
-              attackers = game.current_turn.attacks.count
-
-              attackers.times do
-                token = trigger_effect(:create_token, token_class: SoldierToken, enters_tapped: true).first
-
-                game.current_turn.declare_attacker(token)
-              end
-            }
-          )
+          source.register_turn_trigger(Events::PreliminaryAttackersDeclared, SoldierTokensTrigger)
         end
       end
 

--- a/lib/magic/cards/massacre_girl.rb
+++ b/lib/magic/cards/massacre_girl.rb
@@ -8,21 +8,30 @@ module Magic
       toughness 4
       keywords :menace
 
-      enters_the_battlefield do
-        debuff = -> do
-          game.creatures.except(actor).each do |creature|
-            actor.trigger_effect(:modify_power_toughness, target: creature, power: -1, toughness: -1)
-          end
+      class ETBTrigger < TriggeredAbility::EnterTheBattlefield
+        def call
+          actor.register_turn_trigger(Events::CreatureDied, CreatureDiedTrigger)
+          debuff!
         end
 
-        debuff.call
+        private
 
-        actor.delayed_response(
-          turn: game.current_turn,
-          event_type: Events::CreatureDied,
-          response: debuff,
-        )
+        def debuff!
+          game.creatures.except(actor).each do |creature|
+            trigger_effect(:modify_power_toughness, target: creature, power: -1, toughness: -1)
+          end
+        end
       end
+
+      class CreatureDiedTrigger < TriggeredAbility
+        def call
+          game.creatures.except(actor).each do |creature|
+            trigger_effect(:modify_power_toughness, target: creature, power: -1, toughness: -1)
+          end
+        end
+      end
+
+      def etb_triggers = [ETBTrigger]
     end
   end
 end

--- a/lib/magic/permanent.rb
+++ b/lib/magic/permanent.rb
@@ -17,7 +17,6 @@ module Magic
       :power,
       :toughness,
       :keywords,
-      :delayed_responses,
       :attachments,
       :protections,
       :modifiers,
@@ -65,8 +64,8 @@ module Magic
       @kicked = kicked
       @copy = copy
       @base_types = card.types
-      @delayed_responses = []
       @attachments = []
+      @turn_triggers = {}
       @modifiers = []
       @tapped = false
       @types = card.types
@@ -181,9 +180,13 @@ module Magic
     end
 
     def receive_event(event)
-      trigger_delayed_response(event)
       dispatch_lifecycle_triggers(event)
       dispatch_event_handlers(event)
+      dispatch_turn_triggers(event)
+    end
+
+    def register_turn_trigger(event_class, trigger_class)
+      @turn_triggers[event_class] = Array(@turn_triggers[event_class]) + [trigger_class]
     end
 
     def entered_the_battlefield!(event)
@@ -283,18 +286,8 @@ module Magic
     end
 
 
-    def delayed_response(turn:, event_type:, response:)
-      @delayed_responses << { turn: turn.number, event_type: event_type, response: response }
-    end
-
-    def trigger_delayed_response(event)
-      responses = delayed_responses.select { |response| event.is_a?(response[:event_type]) && response[:turn] == game.current_turn.number }
-      responses.each do |response|
-        response[:response].call
-      end
-    end
-
     def cleanup!
+      @turn_triggers = {}
       remove_until_eot_keyword_grants!
       remove_until_eot_protections!
       remove_until_eot_modifiers!
@@ -410,6 +403,12 @@ module Magic
     def remove_until_eot_modifiers!
       until_eot_modifiers = modifiers.select(&:until_eot?)
       until_eot_modifiers.each { |modifier| modifiers.delete(modifier) }
+    end
+
+    def dispatch_turn_triggers(event)
+      Array(@turn_triggers[event.class]).each do |handler_class|
+        handler_class.new(actor: self, event: event).perform!
+      end
     end
   end
 end

--- a/spec/cards/basri_ket_spec.rb
+++ b/spec/cards/basri_ket_spec.rb
@@ -27,19 +27,15 @@ RSpec.describe Magic::Cards::BasriKet do
   context "-2 triggered ability" do
     let(:ability) { planeswalker.loyalty_abilities[1] }
 
-    let(:turn) { double(Magic::Game::Turn, number: 1, notify!: nil) }
-    before do
-      allow(game).to receive(:current_turn) { turn }
-    end
-
-    it "adds an after attackers declared step trigger" do
+    it "registers a turn trigger for PreliminaryAttackersDeclared" do
       p1.activate_loyalty_ability(ability: ability)
       game.stack.resolve!
       game.tick!
 
       expect(subject.loyalty).to eq(1)
-      expect(subject.delayed_responses.count).to eq(1)
-      expect(subject.delayed_responses.first[:event_type]).to eq(Magic::Events::PreliminaryAttackersDeclared)
+      expect(subject.instance_variable_get(:@turn_triggers)).to include(
+        Magic::Events::PreliminaryAttackersDeclared => [Magic::Cards::BasriKet::SoldierTokensTrigger]
+      )
     end
   end
 


### PR DESCRIPTION
## Summary
- Adds `register_turn_trigger(event_class, trigger_class)` to `Permanent` — proper infrastructure for turn-scoped dynamic trigger registration
- Turn triggers are dispatched alongside static `event_handlers` in `receive_event`, and cleared automatically in `cleanup!` at end of turn
- Rewrites `MassacreGirl`: ETBTrigger registers `CreatureDiedTrigger` for the turn via `actor.register_turn_trigger`
- Rewrites `BasriKet` -2: loyalty ability calls `source.register_turn_trigger` instead of `delayed_response`
- Removes `delayed_response` / `trigger_delayed_response` mechanism entirely
- Emits `AbilityActivated` from `ActivateLoyaltyAbility#perform`, consistent with `ActivateAbility`

## Test plan
- `bundle exec rspec spec/cards/massacre_girl_spec.rb spec/cards/basri_ket_spec.rb` — card-specific behaviour
- `bundle exec rspec` — full suite (554 examples, 0 failures)