### PR TITLE
Add Agatha's Soul Cauldron

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -172,6 +172,27 @@ Pre-built subclasses in `lib/magic/abilities/static/` — declare these on a car
 
 **Pattern**: define an inner class on the card that subclasses the relevant base, implement `applies_to?` and any extra methods, return it from `def static_abilities`. Access the source permanent via `@source`. Example: `AgathasSoulCauldron::GrantAbilitiesFromExile`.
 
+## CardList Helper Methods
+
+`Magic::CardList` (`lib/magic/card_list.rb`) wraps arrays of cards/permanents with filtering helpers. Use these instead of manual `select` with type checks:
+
+- `.creatures` — cards/permanents where `creature?` is true
+- `.lands` — `land?`
+- `.enchantments` — `enchantment?`
+- `.planeswalkers` — `planeswalker?`
+- `.artifacts` — via `.by_any_type(T::Artifact)`
+- `.basic_lands` — `basic_land?`
+- `.shrines` — subtype "Shrine"
+- `.controlled_by(player)` / `.not_controlled_by(player)` — filter by controller
+- `.by_name(name)` — filter by card name
+- `.by_any_type(*types)` — filter by one or more type constants
+- `.cmc_lte(n)` — mana value ≤ n
+- `.nonland` / `.nontoken` — exclusion filters
+- `.except(target)` — exclude a specific card/permanent
+- `.tapped` / `.attacking` — combat/state filters
+
+These return a new `CardList`, so they chain: `source.exiled_cards.creatures.flat_map(&:activated_abilities)`. Prefer these over `select { |c| c.types.include?(T::Creature) }` or similar manual filters.
+
 ## Important Files & Entry Points
 
 - `lib/magic.rb`: Entry point, Zeitwerk setup

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -159,6 +159,19 @@ Pre-built subclasses in `lib/magic/triggered_ability/` — use these to avoid re
 - `TriggeredAbility::SpellCast` — provides `spell`, `enchantment?`
 - `TriggeredAbility::Landfall`, `::Death`, `::LeaveTheBattlefield`, `::CounterAdded`, `::LoreCounterAdded`
 
+## Static Ability Subclasses
+
+Pre-built subclasses in `lib/magic/abilities/static/` — declare these on a card via `def static_abilities = [...]`. `ContinuousEffects` and `ActivateAbility` query them generically; **never add card-class checks to those layers**.
+
+- `Abilities::Static::KeywordGrant` — grants keywords to matching permanents
+- `Abilities::Static::PowerAndToughnessModification` — modifies power/toughness
+- `Abilities::Static::TypeGrant` / `TypeRemoval` — adds/removes types
+- `Abilities::Static::ManaCostAdjustment` — reduces/adjusts mana costs for matching cards
+- `Abilities::Static::AnyColorForCreatureActivations` — controller can spend mana as any color when activating abilities of creature permanents (e.g. Agatha's Soul Cauldron)
+- `Abilities::Static::GrantActivatedAbilities` — grants activated abilities to matching permanents; subclass and implement `applies_to?(permanent)` and `granted_abilities` (e.g. Agatha's Soul Cauldron grants abilities from exiled creature cards to creatures with +1/+1 counters)
+
+**Pattern**: define an inner class on the card that subclasses the relevant base, implement `applies_to?` and any extra methods, return it from `def static_abilities`. Access the source permanent via `@source`. Example: `AgathasSoulCauldron::GrantAbilitiesFromExile`.
+
 ## Important Files & Entry Points
 
 - `lib/magic.rb`: Entry point, Zeitwerk setup

--- a/lib/magic/abilities/static/any_color_for_creature_activations.rb
+++ b/lib/magic/abilities/static/any_color_for_creature_activations.rb
@@ -1,0 +1,13 @@
+# frozen_string_literal: true
+
+module Magic
+  module Abilities
+    module Static
+      class AnyColorForCreatureActivations < StaticAbility
+        def applies_to?(permanent)
+          permanent.types.include?(T::Creature) && permanent.controller == controller
+        end
+      end
+    end
+  end
+end

--- a/lib/magic/abilities/static/grant_activated_abilities.rb
+++ b/lib/magic/abilities/static/grant_activated_abilities.rb
@@ -1,0 +1,13 @@
+# frozen_string_literal: true
+
+module Magic
+  module Abilities
+    module Static
+      class GrantActivatedAbilities < StaticAbility
+        def granted_abilities
+          []
+        end
+      end
+    end
+  end
+end

--- a/lib/magic/actions/activate_ability.rb
+++ b/lib/magic/actions/activate_ability.rb
@@ -94,7 +94,7 @@ module Magic
         cost = costs.find { |cost| cost.is_a?(cost_type) }
         raise "Unknown cost: #{cost_type}" if cost.nil?
 
-        if cost.is_a?(Costs::Mana) && creature_source? && controller_has_cauldron?
+        if cost.is_a?(Costs::Mana) && any_color_for_creature_activations?
           cost.treat_any_color_as_any!
         end
 
@@ -107,12 +107,11 @@ module Magic
         self
       end
 
-      def creature_source?
-        ability.source.types.include?(T::Creature)
-      end
-
-      def controller_has_cauldron?
-        game.battlefield.controlled_by(player).any? { |p| p.card.is_a?(Cards::AgathasSoulCauldron) }
+      def any_color_for_creature_activations?
+        game.battlefield.static_abilities
+          .of_type(Abilities::Static::AnyColorForCreatureActivations)
+          .applies_to(ability.source)
+          .any?
       end
 
       def has_cost?(cost_type)

--- a/lib/magic/actions/activate_ability.rb
+++ b/lib/magic/actions/activate_ability.rb
@@ -94,6 +94,10 @@ module Magic
         cost = costs.find { |cost| cost.is_a?(cost_type) }
         raise "Unknown cost: #{cost_type}" if cost.nil?
 
+        if cost.is_a?(Costs::Mana) && creature_source? && controller_has_cauldron?
+          cost.treat_any_color_as_any!
+        end
+
         pay_method = cost.method(:pay)
         args = {}
         args[:player] = player if pay_method.parameters.include?([:keyreq, :player])
@@ -101,6 +105,14 @@ module Magic
         cost.pay(**args)
 
         self
+      end
+
+      def creature_source?
+        ability.source.types.include?(T::Creature)
+      end
+
+      def controller_has_cauldron?
+        game.battlefield.controlled_by(player).any? { |p| p.card.is_a?(Cards::AgathasSoulCauldron) }
       end
 
       def has_cost?(cost_type)

--- a/lib/magic/cards/agathas_soul_cauldron.rb
+++ b/lib/magic/cards/agathas_soul_cauldron.rb
@@ -47,9 +47,7 @@ module Magic
         end
 
         def granted_abilities
-          @source.exiled_cards
-            .select { |card| card.types.include?(T::Creature) }
-            .flat_map(&:activated_abilities)
+          @source.exiled_cards.creatures.flat_map(&:activated_abilities)
         end
       end
 

--- a/lib/magic/cards/agathas_soul_cauldron.rb
+++ b/lib/magic/cards/agathas_soul_cauldron.rb
@@ -39,8 +39,22 @@ module Magic
       class AnyColorForCreatureActivations < Abilities::Static::AnyColorForCreatureActivations
       end
 
+      class GrantAbilitiesFromExile < Abilities::Static::GrantActivatedAbilities
+        def applies_to?(permanent)
+          permanent.types.include?(T::Creature) &&
+            permanent.controller == controller &&
+            permanent.counters.any? { |c| c.is_a?(Counters::Plus1Plus1) }
+        end
+
+        def granted_abilities
+          @source.exiled_cards
+            .select { |card| card.types.include?(T::Creature) }
+            .flat_map(&:activated_abilities)
+        end
+      end
+
       def activated_abilities = [ExileAbility]
-      def static_abilities = [AnyColorForCreatureActivations]
+      def static_abilities = [AnyColorForCreatureActivations, GrantAbilitiesFromExile]
     end
   end
 end

--- a/lib/magic/cards/agathas_soul_cauldron.rb
+++ b/lib/magic/cards/agathas_soul_cauldron.rb
@@ -1,0 +1,42 @@
+module Magic
+  module Cards
+    AgathasSoulCauldron = Artifact("Agatha's Soul Cauldron") do
+      cost generic: 2
+    end
+
+    class AgathasSoulCauldron < Artifact
+      class CounterChoice < Magic::Choice::Targeted
+        def choices
+          game.creatures.controlled_by(actor.controller)
+        end
+
+        def choice_amount
+          1
+        end
+
+        def resolve!(target:)
+          trigger_effect(:add_counter, target: target, counter_type: Counters::Plus1Plus1)
+        end
+      end
+
+      class ExileAbility < Magic::ActivatedAbility
+        costs "{T}"
+
+        def target_choices
+          game.graveyard_cards
+        end
+
+        def resolve!(target:)
+          trigger_effect(:exile, target: target)
+          source.exiled_cards << target
+
+          if target.types.include?(T::Creature)
+            game.choices.add(CounterChoice.new(actor: source))
+          end
+        end
+      end
+
+      def activated_abilities = [ExileAbility]
+    end
+  end
+end

--- a/lib/magic/cards/agathas_soul_cauldron.rb
+++ b/lib/magic/cards/agathas_soul_cauldron.rb
@@ -36,7 +36,11 @@ module Magic
         end
       end
 
+      class AnyColorForCreatureActivations < Abilities::Static::AnyColorForCreatureActivations
+      end
+
       def activated_abilities = [ExileAbility]
+      def static_abilities = [AnyColorForCreatureActivations]
     end
   end
 end

--- a/lib/magic/costs/mana.rb
+++ b/lib/magic/costs/mana.rb
@@ -17,6 +17,12 @@ module Magic
         @payments = Hash.new(0)
         @payments[:generic] = Hash.new(0)
         @payments[:x] = Hash.new(0)
+        @any_color = false
+        @actual_color_payments = Hash.new(0)
+      end
+
+      def treat_any_color_as_any!
+        @any_color = true
       end
 
       def mana_value
@@ -45,6 +51,11 @@ module Magic
 
       def can_pay?(player)
         return true if cost.values.all?(&:zero?)
+
+        if @any_color
+          total_needed = color_costs.values.sum + (cost[:generic] || 0)
+          return player.mana_pool.values.sum >= total_needed
+        end
 
         pool = player.mana_pool.dup
         deduct_from_pool(pool, color_costs)
@@ -75,7 +86,11 @@ module Magic
         raise CannotPay unless can_pay?(player)
 
         player.pay_mana(@payments[:generic]) if @payments[:generic].any?
-        player.pay_mana(color_costs) if color_costs.values.any?(&:positive?)
+        if @any_color
+          player.pay_mana(@actual_color_payments) if @actual_color_payments.any?
+        else
+          player.pay_mana(color_costs) if color_costs.values.any?(&:positive?)
+        end
       end
 
       def pay!(player:, payment:)
@@ -147,10 +162,21 @@ module Magic
       end
 
       def pay_colors(color_payments)
-        color_payments.each_with_object(balance) do |(color, amount), remaining_balance|
-          remaining_balance[color] -= amount
+        if @any_color
+          remaining = color_payments.values.sum
+          color_costs.each_key do |color|
+            break if remaining <= 0
+            deduction = [balance[color], remaining].min
+            balance[color] -= deduction
+            remaining -= deduction
+          end
+          color_payments.each { |color, amount| @actual_color_payments[color] += amount }
+        else
+          color_payments.each_with_object(balance) do |(color, amount), remaining_balance|
+            remaining_balance[color] -= amount
+          end
+          @payments.merge!(color_payments) { |key, old_value, new_value| old_value + new_value }
         end
-        @payments.merge!(color_payments) { |key, old_value, new_value| old_value + new_value }
       end
 
       def outstanding_balance?

--- a/lib/magic/permanents/continuous_effects.rb
+++ b/lib/magic/permanents/continuous_effects.rb
@@ -112,10 +112,23 @@ module Magic
           *card.activated_abilities,
           # Land types specifically give one mana ability each
           *class_types.flat_map { |type| type::ManaAbility},
+          *cauldron_granted_abilities,
         ]
         .map do |ability|
           ability.new(source: permanent)
         end
+      end
+
+      def cauldron_granted_abilities
+        return [] unless permanent.types.include?(T::Creature)
+        return [] unless permanent.counters.any? { |c| c.is_a?(Counters::Plus1Plus1) }
+
+        game.battlefield
+          .controlled_by(permanent.controller)
+          .select { |p| p.card.is_a?(Cards::AgathasSoulCauldron) }
+          .flat_map { |cauldron| cauldron.exiled_cards }
+          .select { |card| card.types.include?(T::Creature) }
+          .flat_map(&:activated_abilities)
       end
     end
   end

--- a/lib/magic/permanents/continuous_effects.rb
+++ b/lib/magic/permanents/continuous_effects.rb
@@ -112,23 +112,17 @@ module Magic
           *card.activated_abilities,
           # Land types specifically give one mana ability each
           *class_types.flat_map { |type| type::ManaAbility},
-          *cauldron_granted_abilities,
+          *granted_activated_abilities,
         ]
         .map do |ability|
           ability.new(source: permanent)
         end
       end
 
-      def cauldron_granted_abilities
-        return [] unless permanent.types.include?(T::Creature)
-        return [] unless permanent.counters.any? { |c| c.is_a?(Counters::Plus1Plus1) }
-
-        game.battlefield
-          .controlled_by(permanent.controller)
-          .select { |p| p.card.is_a?(Cards::AgathasSoulCauldron) }
-          .flat_map { |cauldron| cauldron.exiled_cards }
-          .select { |card| card.types.include?(T::Creature) }
-          .flat_map(&:activated_abilities)
+      def granted_activated_abilities
+        static_abilities_for(permanent)
+          .of_type(Abilities::Static::GrantActivatedAbilities)
+          .flat_map(&:granted_abilities)
       end
     end
   end

--- a/spec/cards/agathas_soul_cauldron_spec.rb
+++ b/spec/cards/agathas_soul_cauldron_spec.rb
@@ -1,0 +1,140 @@
+# frozen_string_literal: true
+
+RSpec.describe Magic::Cards::AgathasSoulCauldron do
+  include_context "two player game"
+
+  subject(:cauldron) { ResolvePermanent("Agatha's Soul Cauldron", owner: p1) }
+
+  let(:ability) { cauldron.activated_abilities.first }
+
+  context "tap ability — exile target card from a graveyard" do
+    context "when a non-creature card is in the graveyard" do
+      let(:island) { Card("Island", owner: p2) }
+
+      before { island.move_to_graveyard! }
+
+      it "exiles the card and tracks it" do
+        p1.activate_ability(ability: ability) do
+          _1.targeting(island)
+        end
+        game.stack.resolve!
+
+        expect(island.zone).to be_exile
+        expect(cauldron.exiled_cards).to include(island)
+      end
+
+      it "does not add a counter choice" do
+        p1.activate_ability(ability: ability) do
+          _1.targeting(island)
+        end
+        game.stack.resolve!
+
+        expect(game.choices).to be_empty
+      end
+    end
+
+    context "when a creature card is in the graveyard" do
+      let(:wood_elves) { Card("Wood Elves", owner: p2) }
+      let!(:bear) { ResolvePermanent("Grizzly Bears", owner: p1) }
+
+      before { wood_elves.move_to_graveyard! }
+
+      it "exiles the card and tracks it" do
+        p1.activate_ability(ability: ability) do
+          _1.targeting(wood_elves)
+        end
+        game.stack.resolve!
+
+        expect(wood_elves.zone).to be_exile
+        expect(cauldron.exiled_cards).to include(wood_elves)
+      end
+
+      it "adds a counter choice targeting a creature you control" do
+        p1.activate_ability(ability: ability) do
+          _1.targeting(wood_elves)
+        end
+        game.stack.resolve!
+
+        choice = game.choices.first
+        expect(choice).to be_a(described_class::CounterChoice)
+        expect(choice.choices).to include(bear)
+        expect(choice.choices).not_to include(cauldron)
+      end
+
+      it "puts a +1/+1 counter on the chosen creature" do
+        p1.activate_ability(ability: ability) do
+          _1.targeting(wood_elves)
+        end
+        game.stack.resolve!
+        game.resolve_choice!(target: bear)
+        game.tick!
+
+        expect(bear.power).to eq(3)
+        expect(bear.toughness).to eq(3)
+      end
+    end
+  end
+
+  context "ability 2 — grant activated abilities from exiled creature cards" do
+    let(:wood_elves) { Card("Wood Elves", owner: p2) }
+    let!(:bear) { ResolvePermanent("Grizzly Bears", owner: p1) }
+
+    before do
+      wood_elves.move_to_graveyard!
+      # Exile via tap ability to properly track in exiled_cards
+      p1.activate_ability(ability: ability) do
+        _1.targeting(wood_elves)
+      end
+      game.stack.resolve!
+      game.resolve_choice!(target: bear)
+      game.tick!
+    end
+
+    it "grants activated abilities of exiled creature cards to creatures with +1/+1 counters" do
+      expect(bear.activated_abilities.map(&:class)).to include(*wood_elves.activated_abilities)
+    end
+
+    context "when a creature has no +1/+1 counters" do
+      let!(:wolf) { ResolvePermanent("Alpine Watchdog", owner: p1) }
+
+      it "does not grant abilities to creatures without +1/+1 counters" do
+        expect(wolf.activated_abilities.map(&:class)).not_to include(*wood_elves.activated_abilities)
+      end
+    end
+  end
+
+  context "ability 1 — spend mana as though it were any color for creature ability activations" do
+    # Skyway Sniper costs {2}{G} to activate — we pay with all blue mana (no green)
+    let!(:skyway) { ResolvePermanent("Skyway Sniper", owner: p1) }
+
+    before { cauldron } # force Cauldron onto the battlefield
+
+    it "allows spending off-color mana to fulfill a creature ability's colored cost" do
+      p1.add_mana(blue: 3)  # only blue, no green
+      sniper_ability = skyway.activated_abilities.first
+
+      # Verify mana payment succeeds (not resolving the ability — that needs a flying target)
+      expect do
+        p1.activate_ability(ability: sniper_ability) do
+          _1.pay_mana(generic: { blue: 2 }, blue: 1)  # blue substitutes for {G}
+        end
+      end.not_to raise_error
+    end
+
+    it "does not allow off-color spending on non-creature abilities" do
+      # Cauldron itself is an artifact with a tap ability — not a creature, so no any-color benefit
+      p1.add_mana(blue: 3)
+      cauldron_ability = cauldron.activated_abilities.first  # tap ability has no mana cost, so test p2's perspective
+      # Skyway without Cauldron: use p2 who has no Cauldron
+      skyway2 = ResolvePermanent("Skyway Sniper", owner: p2)
+      p2.add_mana(blue: 3)
+      sniper_ability2 = skyway2.activated_abilities.first
+
+      expect do
+        p2.activate_ability(ability: sniper_ability2) do
+          _1.pay_mana(generic: { blue: 2 }, blue: 1)
+        end
+      end.to raise_error(Magic::Costs::Mana::CannotPay)
+    end
+  end
+end


### PR DESCRIPTION
## Summary

Implements all three abilities:

**Ability 1 — any color for creature activations**
- Adds `treat_any_color_as_any!` to `Costs::Mana`: in this mode `can_pay?` checks total mana available vs total needed, and `pay_colors` applies payment to whichever color costs are outstanding
- `ActivateAbility#pay` enables this mode when the ability source is a creature and the controller has a Cauldron on the battlefield

**Ability 2 — grant activated abilities from exiled creature cards**
- `ContinuousEffects#cauldron_granted_abilities` finds Cauldrons the controller controls, collects activated ability classes from their exiled creature cards, and appends them to `calculate_activated_abililities` — only for creatures with +1/+1 counters
- Updates dynamically on every `tick!` via the existing `apply_continuous_effects!` mechanism

**Ability 3 — tap to exile from graveyard, counter if creature**
- `ExileAbility < Magic::ActivatedAbility` with `{T}` cost, targets `game.graveyard_cards`
- On resolve: exiles the card (effects system) and adds to `source.exiled_cards` for tracking; if the exiled card is a creature, pushes a `CounterChoice` targeting a creature the controller controls

## Test plan
- `bundle exec rspec spec/cards/agathas_soul_cauldron_spec.rb` — 9 examples covering all three abilities
- `bundle exec rspec` — 563 examples, 0 failures