### PR TITLE
Use string counter names instead of Counters:: class constants

### DIFF
--- a/lib/magic/cards/academy_elite.rb
+++ b/lib/magic/cards/academy_elite.rb
@@ -11,7 +11,7 @@ module Magic
       class ETB < TriggeredAbility::EnterTheBattlefield
         def call
           counters = game.graveyard_cards.by_any_type(T::Instant, T::Sorcery).count
-          actor.trigger_effect(:add_counter, target: actor, counter_type: Counters::Plus1Plus1, amount: counters)
+          actor.trigger_effect(:add_counter, target: actor, counter_type: "+1/+1", amount: counters)
         end
       end
 

--- a/lib/magic/cards/agathas_soul_cauldron.rb
+++ b/lib/magic/cards/agathas_soul_cauldron.rb
@@ -15,7 +15,7 @@ module Magic
         end
 
         def resolve!(target:)
-          trigger_effect(:add_counter, target: target, counter_type: Counters::Plus1Plus1)
+          trigger_effect(:add_counter, target: target, counter_type: "+1/+1")
         end
       end
 

--- a/lib/magic/cards/ajanis_pridemate.rb
+++ b/lib/magic/cards/ajanis_pridemate.rb
@@ -16,7 +16,7 @@ module Magic
           actor.trigger_effect(
             :add_counter,
             target: actor,
-            counter_type: Counters::Plus1Plus1,
+            counter_type: "+1/+1",
             amount: event.life
           )
         end

--- a/lib/magic/cards/animal_sanctuary.rb
+++ b/lib/magic/cards/animal_sanctuary.rb
@@ -27,7 +27,7 @@ module Magic
         end
 
         def resolve!(target:)
-          trigger_effect(:add_counter, counter_type: Counters::Plus1Plus1, target: target)
+          trigger_effect(:add_counter, counter_type: "+1/+1", target: target)
         end
       end
 

--- a/lib/magic/cards/aron_benalias_ruin.rb
+++ b/lib/magic/cards/aron_benalias_ruin.rb
@@ -13,7 +13,7 @@ module Magic
 
         def resolve!
           creatures_you_control.each do |creature|
-            creature.add_counter(counter_type: Counters::Plus1Plus1)
+            creature.add_counter("+1/+1")
           end
         end
       end

--- a/lib/magic/cards/basri_ket.rb
+++ b/lib/magic/cards/basri_ket.rb
@@ -15,7 +15,7 @@ module Magic
             trigger_effect(:create_token, token_class: SoldierToken, controller: owner)
 
             owner.creatures.each do |creature|
-              trigger_effect(:add_counter, target: creature, counter_type: Counters::Plus1Plus1)
+              trigger_effect(:add_counter, target: creature, counter_type: "+1/+1")
             end
           end
         end
@@ -36,7 +36,7 @@ module Magic
         end
 
         def resolve!(target:)
-          target.add_counter(counter_type: Counters::Plus1Plus1)
+          target.add_counter("+1/+1")
           target.grant_indestructible!
         end
       end

--- a/lib/magic/cards/basris_acolyte.rb
+++ b/lib/magic/cards/basris_acolyte.rb
@@ -15,7 +15,7 @@ module Magic
         end
 
         def resolve!(target:)
-          actor.trigger_effect(:add_counter, counter_type: Counters::Plus1Plus1, source: actor, target: target)
+          actor.trigger_effect(:add_counter, counter_type: "+1/+1", source: actor, target: target)
           choice = SecondChoice.new(actor: actor, choices: choices - [target])
           game.choices.add(choice)
         end
@@ -30,7 +30,7 @@ module Magic
         end
 
         def resolve!(target:)
-          actor.trigger_effect(:add_counter, counter_type: Counters::Plus1Plus1, source: actor, target: target)
+          actor.trigger_effect(:add_counter, counter_type: "+1/+1", source: actor, target: target)
         end
       end
 

--- a/lib/magic/cards/basris_lieutenant.rb
+++ b/lib/magic/cards/basris_lieutenant.rb
@@ -32,7 +32,7 @@ module Magic
         end
 
         def resolve!(target:)
-          actor.trigger_effect(:add_counter, counter_type: Counters::Plus1Plus1, target: target)
+          actor.trigger_effect(:add_counter, counter_type: "+1/+1", target: target)
         end
       end
 

--- a/lib/magic/cards/basris_solidarity.rb
+++ b/lib/magic/cards/basris_solidarity.rb
@@ -7,7 +7,7 @@ module Magic
     class BasrisSolidarity < Sorcery
       def resolve!
         controller.creatures.each do |creature|
-          creature.add_counter(counter_type: Counters::Plus1Plus1)
+          creature.add_counter("+1/+1")
         end
 
         super

--- a/lib/magic/cards/conclave_mentor.rb
+++ b/lib/magic/cards/conclave_mentor.rb
@@ -9,7 +9,7 @@ module Magic
 
       class AddMoreCounters < ReplacementEffect
         def applies?(effect)
-          effect.counter_type == Counters::Plus1Plus1 &&
+          effect.counter_type == "+1/+1" &&
             effect.target.controller == receiver.controller &&
             effect.target.creature?
         end
@@ -17,7 +17,7 @@ module Magic
         def call(effect)
           Effects::AddCounterToPermanent.new(
             source: receiver,
-            counter_type: Counters::Plus1Plus1,
+            counter_type: "+1/+1",
             target: effect.target,
             amount: effect.amount + 1,
           )

--- a/lib/magic/cards/feat_of_resistance.rb
+++ b/lib/magic/cards/feat_of_resistance.rb
@@ -26,7 +26,7 @@ module Magic
       end
 
       def resolve!(target:)
-        target.add_counter(counter_type: Counters::Plus1Plus1)
+        target.add_counter("+1/+1")
         game.choices.add(Choice.new(actor: self, target: target))
       end
     end

--- a/lib/magic/cards/light_of_promise.rb
+++ b/lib/magic/cards/light_of_promise.rb
@@ -16,7 +16,7 @@ module Magic
         end
 
         def call
-          actor.attached_to.add_counter(counter_type: Counters::Plus1Plus1, amount: event.life)
+          actor.attached_to.add_counter("+1/+1", amount: event.life)
         end
       end
 

--- a/lib/magic/cards/lorescale_coatl.rb
+++ b/lib/magic/cards/lorescale_coatl.rb
@@ -13,7 +13,7 @@ module Magic
         end
 
         def call
-          actor.trigger_effect(:add_counter, source: actor, counter_type: Counters::Plus1Plus1, target: actor)
+          actor.trigger_effect(:add_counter, source: actor, counter_type: "+1/+1", target: actor)
         end
       end
 

--- a/lib/magic/cards/makeshift_batallion.rb
+++ b/lib/magic/cards/makeshift_batallion.rb
@@ -18,7 +18,7 @@ module Magic
         end
 
         def call
-          actor.add_counter(counter_type: Counters::Plus1Plus1)
+          actor.add_counter("+1/+1")
         end
       end
 

--- a/lib/magic/cards/mazemind_tome.rb
+++ b/lib/magic/cards/mazemind_tome.rb
@@ -9,7 +9,7 @@ module Magic
         def costs
           [
             Costs::SelfTap.new(source),
-            Costs::AddCounter.new(counter_type: Counters::Page, target: source)
+            Costs::AddCounter.new(counter_type: "page", target: source)
           ]
         end
 
@@ -23,7 +23,7 @@ module Magic
           [
             Costs::Mana.new(generic: 2),
             Costs::SelfTap.new(source),
-            Costs::AddCounter.new(counter_type: Counters::Page, target: source)
+            Costs::AddCounter.new(counter_type: "page", target: source)
           ]
         end
 

--- a/lib/magic/cards/nine_lives.rb
+++ b/lib/magic/cards/nine_lives.rb
@@ -14,7 +14,7 @@ module Magic
         def call(effect)
           Effects::AddCounterToPermanent.new(
             source: receiver,
-            counter_type: Counters::Incarnation,
+            counter_type: "incarnation",
             target: receiver,
           )
         end

--- a/lib/magic/cards/pridemalkin.rb
+++ b/lib/magic/cards/pridemalkin.rb
@@ -20,7 +20,7 @@ module Magic
             :add_counter,
             source: actor,
             target: target,
-            counter_type: Counters::Plus1Plus1
+            counter_type: "+1/+1"
           )
         end
       end

--- a/lib/magic/cards/saga.rb
+++ b/lib/magic/cards/saga.rb
@@ -15,7 +15,7 @@ module Magic
       type T::Enchantment, 'Saga'
 
       enters_the_battlefield do
-        actor.trigger_effect(:add_counter, counter_type: Magic::Counters::Lore, target: actor)
+        actor.trigger_effect(:add_counter, counter_type: "lore", target: actor)
       end
 
       class FirstMainPhaseTrigger < TriggeredAbility
@@ -24,7 +24,7 @@ module Magic
         end
 
         def call
-          actor.trigger_effect(:add_counter, counter_type: Magic::Counters::Lore, target: actor)
+          actor.trigger_effect(:add_counter, counter_type: "lore", target: actor)
         end
       end
 

--- a/lib/magic/cards/sazhs_chocobo.rb
+++ b/lib/magic/cards/sazhs_chocobo.rb
@@ -14,7 +14,7 @@ module Magic
         end
 
         def call
-          trigger_effect(:add_counter, target: actor, counter_type: Counters["+1/+1"])
+          trigger_effect(:add_counter, target: actor, counter_type: "+1/+1")
         end
       end
 

--- a/lib/magic/cards/scavenging_ooze.rb
+++ b/lib/magic/cards/scavenging_ooze.rb
@@ -20,7 +20,7 @@ module Magic
         def resolve!(target:)
           trigger_effect(:exile, target: target)
           if target.creature?
-            source.add_counter(counter_type: Counters::Plus1Plus1)
+            source.add_counter("+1/+1")
             source.controller.gain_life(1)
           end
         end

--- a/lib/magic/cards/shalais_acolyte.rb
+++ b/lib/magic/cards/shalais_acolyte.rb
@@ -17,7 +17,7 @@ module Magic
             actor.trigger_effect(
               :add_counter,
               target: actor,
-              counter_type: Counters::Plus1Plus1,
+              counter_type: "+1/+1",
               amount: 2
             )
           end

--- a/lib/magic/cards/tempered_veteran.rb
+++ b/lib/magic/cards/tempered_veteran.rb
@@ -20,7 +20,7 @@ module Magic
         def resolve!(target:)
           trigger_effect(
             :add_counter,
-            counter_type: Counters::Plus1Plus1,
+            counter_type: "+1/+1",
             target: target,
           )
         end
@@ -40,7 +40,7 @@ module Magic
         def resolve!(target:)
           trigger_effect(
             :add_counter,
-            counter_type: Counters::Plus1Plus1,
+            counter_type: "+1/+1",
             target: target,
           )
         end

--- a/lib/magic/costs/add_counter.rb
+++ b/lib/magic/costs/add_counter.rb
@@ -9,7 +9,7 @@ module Magic
       end
 
       def finalize!(_player)
-        target.add_counter(counter_type: counter_type)
+        target.add_counter(counter_type)
       end
     end
   end

--- a/lib/magic/counters.rb
+++ b/lib/magic/counters.rb
@@ -1,13 +1,16 @@
 module Magic
   module Counters
-    def self.[](counter_name)
-      case counter_name
-      when "+1/+1"
-        Plus1Plus1
-      when "-1/-1"
-        Minus1Minus1
+    def self.[](counter_type)
+      return counter_type if counter_type.is_a?(Class)
+      case counter_type
+      when "+1/+1" then Plus1Plus1
+      when "-1/-1" then Minus1Minus1
+      when "lore" then Lore
+      when "incarnation" then Incarnation
+      when "page" then Page
+      when "poison" then Poison
       else
-        raise "Unknown counter type: #{counter_name}"
+        raise "Unknown counter type: #{counter_type}"
       end
     end
   end

--- a/lib/magic/effects/add_counter_to_permanent.rb
+++ b/lib/magic/effects/add_counter_to_permanent.rb
@@ -14,7 +14,7 @@ module Magic
       end
 
       def resolve!
-        target.add_counter(counter_type:, amount:)
+        target.add_counter(counter_type, amount:)
 
         game.notify!(
           Events::CounterAddedToPermanent.new(

--- a/lib/magic/effects/add_counter_to_player.rb
+++ b/lib/magic/effects/add_counter_to_player.rb
@@ -15,7 +15,7 @@ module Magic
       end
 
       def resolve!
-        target.add_counter(counter_type:, amount:)
+        target.add_counter(counter_type, amount:)
 
         game.notify!(
           Events::CounterAddedToPlayer.new(

--- a/lib/magic/effects/deal_combat_damage.rb
+++ b/lib/magic/effects/deal_combat_damage.rb
@@ -12,7 +12,7 @@ module Magic
         if target.player? && source.has_keyword?(Magic::Keywords::Toxic)
           source.trigger_effect(
             :add_counter,
-            counter_type: Counters::Poison,
+            counter_type: "poison",
             target: target,
           )
           deal_combat_damage!
@@ -20,7 +20,7 @@ module Magic
         elsif target.player? && source.has_keyword?(Magic::Keywords::INFECT)
           source.trigger_effect(
             :add_counter,
-            counter_type: Counters::Poison,
+            counter_type: "poison",
             target: target,
             amount: damage,
           )

--- a/lib/magic/permanent.rb
+++ b/lib/magic/permanent.rb
@@ -295,8 +295,9 @@ module Magic
       apply_continuous_effects!
     end
 
-    def add_counter(counter_type:, amount: 1)
-      @counters = Counters::Collection.new(@counters + [counter_type.new] * amount)
+    def add_counter(counter_type, amount: 1)
+      resolved = Counters[counter_type]
+      @counters = Counters::Collection.new(@counters + [resolved.new] * amount)
     end
 
     def remove_counter(counter_type:, amount: 1)

--- a/lib/magic/player.rb
+++ b/lib/magic/player.rb
@@ -295,8 +295,9 @@ module Magic
       permanents.flat_map { |card| card.protections.player }.any? { |protection| protection.protected_from?(card) }
     end
 
-    def add_counter(counter_type:, amount: 1)
-      @counters = Counters::Collection.new(@counters + [counter_type.new] * amount)
+    def add_counter(counter_type, amount: 1)
+      resolved = Counters[counter_type]
+      @counters = Counters::Collection.new(@counters + [resolved.new] * amount)
     end
 
     def devotion(color)

--- a/lib/magic/triggered_ability/lore_counter_added.rb
+++ b/lib/magic/triggered_ability/lore_counter_added.rb
@@ -2,7 +2,7 @@ module Magic
   class TriggeredAbility
     class LoreCounterAdded < TriggeredAbility
       def should_perform?
-        event.counter_type == Magic::Counters::Lore
+        event.counter_type == "lore"
       end
 
     end

--- a/spec/cards/academy_elite_spec.rb
+++ b/spec/cards/academy_elite_spec.rb
@@ -60,7 +60,7 @@ RSpec.describe Magic::Cards::AcademyElite do
     let(:academy_elite) { ResolvePermanent("Academy Elite", owner: p1) }
 
     before do
-      academy_elite.add_counter(counter_type: Magic::Counters::Plus1Plus1)
+      academy_elite.add_counter("+1/+1")
     end
 
     it "removes a +1/+1 counter, draws a card and discards a card" do

--- a/spec/cards/basris_lieutenant_spec.rb
+++ b/spec/cards/basris_lieutenant_spec.rb
@@ -27,7 +27,7 @@ RSpec.describe Magic::Cards::BasrisLieutenant do
   context "on death -- when basri's lieutenant is on the battlefield" do
     context "when the death is this card and it had a counter" do
       before do
-        subject.add_counter(counter_type: Magic::Counters::Plus1Plus1)
+        subject.add_counter("+1/+1")
       end
 
       it "creates a 2/2 white knight creature token with vigilance" do
@@ -45,7 +45,7 @@ RSpec.describe Magic::Cards::BasrisLieutenant do
       let(:elves) { ResolvePermanent("Wood Elves", owner: p1) }
       before do
         subject
-        elves.add_counter(counter_type: Magic::Counters::Plus1Plus1)
+        elves.add_counter("+1/+1")
       end
 
       it "creates a 2/2 white knight creature token with vigilance" do

--- a/spec/cards/conclave_mentor_spec.rb
+++ b/spec/cards/conclave_mentor_spec.rb
@@ -8,7 +8,7 @@ RSpec.describe Magic::Cards::ConclaveMentor do
   it "if one or more counters would be put on a creature you control" do
     effect = Magic::Effects::AddCounterToPermanent.new(
       source: wood_elves,
-      counter_type: Magic::Counters::Plus1Plus1,
+      counter_type: "+1/+1",
       target: wood_elves,
     )
 

--- a/spec/cards/tempered_veteran_spec.rb
+++ b/spec/cards/tempered_veteran_spec.rb
@@ -11,7 +11,7 @@ RSpec.describe Magic::Cards::TemperedVeteran do
 
     it "adds a counter to a creature with a counter" do
       p1.add_mana(white: 2)
-      wood_elves.add_counter(counter_type: Magic::Counters::Plus1Plus1)
+      wood_elves.add_counter("+1/+1")
       p1.activate_ability(ability: ability) do
         _1.targeting(wood_elves).pay_mana(white: 1)
       end

--- a/spec/game/integration/replacement_effect_choice_order_spec.rb
+++ b/spec/game/integration/replacement_effect_choice_order_spec.rb
@@ -10,7 +10,7 @@ RSpec.describe Magic::Game, "replacement effects -- chooser controls application
   def counter_effect
     Magic::Effects::AddCounterToPermanent.new(
       source: wood_elves,
-      counter_type: Magic::Counters::Plus1Plus1,
+      counter_type: "+1/+1",
       target: wood_elves,
       amount: 1,
     )

--- a/spec/game/integration/replacement_effect_semantic_applicability_spec.rb
+++ b/spec/game/integration/replacement_effect_semantic_applicability_spec.rb
@@ -15,7 +15,7 @@ RSpec.describe Magic::Game, "replacement effects -- semantic applicability" do
 
       effect = subclassed_counter_effect.new(
         source: wood_elves,
-        counter_type: Magic::Counters::Plus1Plus1,
+        counter_type: "+1/+1",
         target: wood_elves,
         amount: 1,
       )
@@ -30,7 +30,7 @@ RSpec.describe Magic::Game, "replacement effects -- semantic applicability" do
 
       effect = subclassed_counter_effect.new(
         source: wood_elves,
-        counter_type: Magic::Counters::Plus1Plus1,
+        counter_type: "+1/+1",
         target: wood_elves,
         amount: 1,
       )


### PR DESCRIPTION
## Summary

- `add_counter` now accepts a string counter name resolved via `Counters[]` — e.g. `add_counter("+1/+1")` instead of `add_counter(counter_type: Counters::Plus1Plus1)`
- `Counters[]` registry extended to cover all counter types: `lore`, `incarnation`, `page`, `poison` (in addition to existing `+1/+1` and `-1/-1`)
- Class passthrough preserved in `Counters[]` for internal propagation (e.g. `DoublingSeason` re-using `effect.counter_type`)
- Comparisons against counter type classes (`== Counters::Lore`, `== Counters::Plus1Plus1`) updated to string equivalents
- 36 files updated; 571 tests pass

🤖 Generated with [Claude Code](https://claude.com/claude-code)