### PR TITLE
Implement Thrashing Brontodon

### DIFF
--- a/lib/magic/cards/thrashing_brontodon.rb
+++ b/lib/magic/cards/thrashing_brontodon.rb
@@ -1,0 +1,30 @@
+module Magic
+  module Cards
+    ThrashingBrontodon = Creature("Thrashing Brontodon") do
+      cost generic: 1, green: 2
+      creature_type "Dinosaur"
+      power 3
+      toughness 4
+    end
+
+    class ThrashingBrontodon < Creature
+      class DestroyArtifactOrEnchantment < Magic::ActivatedAbility
+        costs "{1}, Sacrifice {this}"
+
+        def single_target?
+          true
+        end
+
+        def target_choices
+          game.battlefield.by_any_type("Artifact", "Enchantment")
+        end
+
+        def resolve!(target:)
+          target.destroy!
+        end
+      end
+
+      def activated_abilities = [DestroyArtifactOrEnchantment]
+    end
+  end
+end

--- a/spec/cards/thrashing_brontodon_spec.rb
+++ b/spec/cards/thrashing_brontodon_spec.rb
@@ -1,0 +1,54 @@
+# frozen_string_literal: true
+
+require "spec_helper"
+
+RSpec.describe Magic::Cards::ThrashingBrontodon do
+  include_context "two player game"
+
+  subject(:brontodon) { ResolvePermanent("Thrashing Brontodon", owner: p1) }
+
+  it "is a 3/4 Dinosaur" do
+    expect(brontodon.power).to eq(3)
+    expect(brontodon.toughness).to eq(4)
+  end
+
+  context "activated ability: destroy target artifact or enchantment" do
+    let(:ability) { brontodon.activated_abilities.first }
+
+    context "targeting an artifact" do
+      let!(:great_furnace) { ResolvePermanent("Great Furnace", owner: p2) }
+
+      it "destroys the artifact and sacrifices itself" do
+        p1.add_mana(green: 1)
+        p1.activate_ability(ability: ability) do
+          _1.pay_mana(generic: { green: 1 })
+          _1.targeting(great_furnace)
+        end
+
+        game.stack.resolve!
+        game.tick!
+
+        expect(great_furnace.zone).to be_nil
+        expect(brontodon.zone).to be_nil
+      end
+    end
+
+    context "targeting an enchantment" do
+      let!(:rhystic_study) { ResolvePermanent("Rhystic Study", owner: p2) }
+
+      it "destroys the enchantment and sacrifices itself" do
+        p1.add_mana(green: 1)
+        p1.activate_ability(ability: ability) do
+          _1.pay_mana(generic: { green: 1 })
+          _1.targeting(rhystic_study)
+        end
+
+        game.stack.resolve!
+        game.tick!
+
+        expect(rhystic_study.zone).to be_nil
+        expect(brontodon.zone).to be_nil
+      end
+    end
+  end
+end


### PR DESCRIPTION
Implements Thrashing Brontodon — a 3/4 Dinosaur for {1}{G}{G} with the activated ability: {1}, Sacrifice this creature: Destroy target artifact or enchantment.

Closes #220