### PR TITLE
Implement Trufflesnout

### DIFF
--- a/lib/magic/cards/trufflesnout.rb
+++ b/lib/magic/cards/trufflesnout.rb
@@ -1,0 +1,34 @@
+module Magic
+  module Cards
+    Trufflesnout = Creature("Trufflesnout") do
+      cost generic: 2, green: 1
+      creature_type "Boar"
+      power 2
+      toughness 2
+    end
+
+    class Trufflesnout < Creature
+      class Choice < Magic::Choice
+        COUNTER = :counter
+        GAIN_LIFE = :gain_life
+
+        def resolve!(mode:)
+          case mode
+          when COUNTER
+            trigger_effect(:add_counter, target: actor, counter_type: "+1/+1")
+          when GAIN_LIFE
+            controller.gain_life(4)
+          end
+        end
+      end
+
+      class ETB < TriggeredAbility::EnterTheBattlefield
+        def call
+          game.choices.add(Choice.new(actor: actor))
+        end
+      end
+
+      def etb_triggers = [ETB]
+    end
+  end
+end

--- a/spec/cards/trufflesnout_spec.rb
+++ b/spec/cards/trufflesnout_spec.rb
@@ -1,0 +1,36 @@
+# frozen_string_literal: true
+require "spec_helper"
+
+RSpec.describe Magic::Cards::Trufflesnout do
+  include_context "two player game"
+
+  let(:trufflesnout) { ResolvePermanent("Trufflesnout", owner: p1) }
+
+  describe "entering the battlefield" do
+    before { trufflesnout }
+
+    it "presents a choice" do
+      expect(game.choices.last).to be_a(Magic::Cards::Trufflesnout::Choice)
+    end
+
+    context "when choosing to put a +1/+1 counter on itself" do
+      before do
+        game.resolve_choice!(mode: Magic::Cards::Trufflesnout::Choice::COUNTER)
+        game.tick!
+      end
+
+      it "puts a +1/+1 counter on itself" do
+        expect(trufflesnout.power).to eq(3)
+        expect(trufflesnout.toughness).to eq(3)
+      end
+    end
+
+    context "when choosing to gain 4 life" do
+      before { game.resolve_choice!(mode: Magic::Cards::Trufflesnout::Choice::GAIN_LIFE) }
+
+      it "gains 4 life for the controller" do
+        expect(p1.life).to eq(24)
+      end
+    end
+  end
+end


### PR DESCRIPTION
Closes #223

## Summary
- Implements Trufflesnout (2G, 2/2 Boar, Core Set 2021)
- ETB triggered ability presents a modal choice: put a +1/+1 counter on itself, or gain 4 life
- Uses `Magic::Choice` subclass with two modes (`COUNTER`, `GAIN_LIFE`)

## Test plan
- [ ] Presents a choice when entering the battlefield
- [ ] Choosing counter mode puts a +1/+1 counter on Trufflesnout (power/toughness become 3/3)
- [ ] Choosing life gain mode grants controller 4 life (total 24)

🤖 Generated with [Claude Code](https://claude.com/claude-code)