### PR TITLE
Add Sabertooth Mauler

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -10,3 +10,4 @@
 
 # rspec failure tracking
 .rspec_status
+.claude

--- a/lib/magic/cards/sabertooth_mauler.rb
+++ b/lib/magic/cards/sabertooth_mauler.rb
@@ -1,0 +1,29 @@
+module Magic
+  module Cards
+    class SabertoothMauler < Creature
+      card_name "Sabertooth Mauler"
+      creature_type "Cat"
+      cost generic: 3, green: 1
+      power 3
+      toughness 3
+
+      class EndStepTrigger < TriggeredAbility::BeginningOfEndStep
+        def should_perform?
+          return false unless controllers_end_step?
+          game.current_turn.events.any? { |e| e.is_a?(Events::CreatureDied) }
+        end
+
+        def call
+          trigger_effect(:add_counter, counter_type: "+1/+1", source: actor, target: actor)
+          actor.untap!
+        end
+      end
+
+      def event_handlers
+        {
+          Events::BeginningOfEndStep => EndStepTrigger
+        }
+      end
+    end
+  end
+end

--- a/spec/cards/sabertooth_mauler_spec.rb
+++ b/spec/cards/sabertooth_mauler_spec.rb
@@ -1,0 +1,48 @@
+# frozen_string_literal: true
+
+require "spec_helper"
+
+RSpec.describe Magic::Cards::SabertoothMauler do
+  include_context "two player game"
+
+  let!(:mauler) { ResolvePermanent("Sabertooth Mauler") }
+
+  context "when no creature has died" do
+    it "does not add a counter or untap" do
+      mauler.tap!
+      game.current_turn.end!
+      expect(mauler.counters).to be_empty
+      expect(mauler).to be_tapped
+    end
+  end
+
+  context "when a creature has died on controller's end step" do
+    before do
+      wood_elves = ResolvePermanent("Wood Elves", owner: p2)
+      wood_elves.destroy!
+    end
+
+    it "puts a +1/+1 counter on Sabertooth Mauler and untaps it" do
+      mauler.tap!
+      game.current_turn.end!
+      expect(mauler.counters.count).to eq(1)
+      expect(mauler.counters.first).to be_a(Magic::Counters::Plus1Plus1)
+      expect(mauler).to be_untapped
+    end
+  end
+
+  context "when a creature has died on opponent's end step" do
+    before do
+      game.next_turn
+      wood_elves = ResolvePermanent("Wood Elves", owner: p2)
+      wood_elves.destroy!
+    end
+
+    it "does not trigger" do
+      mauler.tap!
+      game.current_turn.end!
+      expect(mauler.counters).to be_empty
+      expect(mauler).to be_tapped
+    end
+  end
+end


### PR DESCRIPTION
## Summary
- Implements Sabertooth Mauler ({3}{G} 3/3 Cat) from Core Set 2021
- At beginning of controller's end step, if a creature died this turn, adds a +1/+1 counter and untaps
- Reuses `TriggeredAbility::BeginningOfEndStep` and `current_turn.events` (same pattern as Twinblade Assassins)

Closes #212

## Test plan
- [x] No trigger when no creature died
- [x] Trigger on controller's end step after death (counter + untap)
- [x] No trigger on opponent's end step
- [x] Full suite: 618 examples, 0 failures

🤖 Generated with [Claude Code](https://claude.com/claude-code)