### PR TITLE
Add Ornery Dilophosaur

### DIFF
--- a/lib/magic/cards/ornery_dilophosaur.rb
+++ b/lib/magic/cards/ornery_dilophosaur.rb
@@ -1,0 +1,31 @@
+module Magic
+  module Cards
+    OrneryDilophosaur = Creature("Ornery Dilophosaur") do
+      creature_type "Dinosaur"
+      cost generic: 2, green: 1
+      power 3
+      toughness 3
+      keywords :deathtouch
+    end
+
+    class OrneryDilophosaur < Creature
+      class AttackTrigger < TriggeredAbility
+        def should_perform?
+          return false unless event.attacks.any? { |attack| attack.attacker == actor }
+
+          creatures_you_control.with_power { |power| power >= 4 }.any?
+        end
+
+        def call
+          actor.trigger_effect(:modify_power_toughness, power: 2, toughness: 2, target: actor, until_eot: true)
+        end
+      end
+
+      def event_handlers
+        {
+          Events::FinalAttackersDeclared => AttackTrigger
+        }
+      end
+    end
+  end
+end

--- a/spec/cards/ornery_dilophosaur_spec.rb
+++ b/spec/cards/ornery_dilophosaur_spec.rb
@@ -1,0 +1,56 @@
+# frozen_string_literal: true
+
+require 'spec_helper'
+
+RSpec.describe Magic::Cards::OrneryDilophosaur do
+  include_context "two player game"
+
+  subject(:dilophosaur) { ResolvePermanent("Ornery Dilophosaur", owner: p1) }
+
+  it "has deathtouch" do
+    expect(dilophosaur.deathtouch?).to eq(true)
+  end
+
+  context "when attacking" do
+    before do
+      dilophosaur
+      skip_to_combat!
+    end
+
+    context "when the controller does not control a creature with power 4 or greater" do
+      let!(:wood_elves) { ResolvePermanent("Wood Elves", owner: p1) }
+
+      it "does not get +2/+2" do
+        current_turn.declare_attackers!
+        p1.declare_attacker(attacker: dilophosaur, target: p2)
+        current_turn.attackers_declared!
+        game.tick!
+
+        expect(dilophosaur.power).to eq(3)
+        expect(dilophosaur.toughness).to eq(3)
+      end
+    end
+
+    context "when the controller controls a creature with power 4 or greater" do
+      let!(:colossal_dreadmaw) { ResolvePermanent("Colossal Dreadmaw", owner: p1) }
+
+      it "gets +2/+2 until end of turn" do
+        current_turn.declare_attackers!
+        p1.declare_attacker(attacker: dilophosaur, target: p2)
+        current_turn.attackers_declared!
+        game.tick!
+
+        expect(dilophosaur.power).to eq(5)
+        expect(dilophosaur.toughness).to eq(5)
+
+        game.current_turn.end!
+        game.current_turn.cleanup!
+        game.next_turn
+        game.tick!
+
+        expect(dilophosaur.power).to eq(3)
+        expect(dilophosaur.toughness).to eq(3)
+      end
+    end
+  end
+end


### PR DESCRIPTION
## Summary
- Implements Ornery Dilophosaur (Core Set 2021), a 3/3 Dinosaur for {2}{G} with deathtouch.
- On attack, if the controller controls a creature with power 4 or greater (including itself once buffed), Ornery Dilophosaur gets +2/+2 until end of turn.

Closes #204

## Test plan
- [x] `bundle exec rspec spec/cards/ornery_dilophosaur_spec.rb` (3 examples, 0 failures)
- [x] `bundle exec rspec` (full suite, 0 failures)

Tests cover:
- Has deathtouch.
- No buff when no controlled creature has power >= 4.
- Gets +2/+2 when a controlled creature has power >= 4, and the buff wears off after end of turn.

🤖 Generated with [Claude Code](https://claude.com/claude-code)