### PR TITLE
Add Ranger's Guile

### DIFF
--- a/lib/magic/cards/rangers_guile.rb
+++ b/lib/magic/cards/rangers_guile.rb
@@ -1,0 +1,23 @@
+module Magic
+  module Cards
+    RangersGuile = Instant("Ranger's Guile") do
+      cost green: 1
+    end
+
+    class RangersGuile < Instant
+      def single_target?
+        true
+      end
+
+      def target_choices
+        controller.creatures
+      end
+
+      def resolve!(target:)
+        target.modify_power(1)
+        target.modify_toughness(1)
+        target.grant_hexproof!
+      end
+    end
+  end
+end

--- a/spec/cards/rangers_guile_spec.rb
+++ b/spec/cards/rangers_guile_spec.rb
@@ -1,0 +1,49 @@
+# frozen_string_literal: true
+
+require 'spec_helper'
+
+RSpec.describe Magic::Cards::RangersGuile do
+  include_context "two player game"
+
+  let!(:wood_elves) { ResolvePermanent("Wood Elves", owner: p1) }
+
+  it "gives target creature you control +1/+1 and hexproof until end of turn" do
+    p1.add_mana(green: 1)
+    p1.cast(card: Card("Ranger's Guile")) do
+      _1.auto_pay_mana
+      _1.targeting(wood_elves)
+    end
+
+    game.stack.resolve!
+    game.tick!
+
+    expect(wood_elves.power).to eq(2)
+    expect(wood_elves.toughness).to eq(2)
+    expect(wood_elves.hexproof?).to eq(true)
+    expect(wood_elves.keyword_grant_modifiers.first.until_eot?).to eq(true)
+  end
+
+  it "the +1/+1 boost and hexproof wear off after end of turn" do
+    p1.add_mana(green: 1)
+    p1.cast(card: Card("Ranger's Guile")) do
+      _1.auto_pay_mana
+      _1.targeting(wood_elves)
+    end
+
+    game.stack.resolve!
+    game.tick!
+
+    expect(wood_elves.power).to eq(2)
+    expect(wood_elves.toughness).to eq(2)
+    expect(wood_elves.hexproof?).to eq(true)
+
+    game.current_turn.end!
+    game.current_turn.cleanup!
+    game.next_turn
+    game.tick!
+
+    expect(wood_elves.power).to eq(1)
+    expect(wood_elves.toughness).to eq(1)
+    expect(wood_elves.hexproof?).to eq(false)
+  end
+end


### PR DESCRIPTION
## Summary
- Implements Ranger's Guile (Core Set 2021 reprint): instant, cost {G}, target creature you control gets +1/+1 and gains hexproof until end of turn.
- Uses the existing direct modifier pattern (Sure Strike / Heroic Intervention): `target.modify_power(1)`, `target.modify_toughness(1)`, `target.grant_hexproof!` — all default to `until_eot: true`.

Closes #209

## Test plan
- [x] `bundle exec rspec spec/cards/rangers_guile_spec.rb` — 2 examples, 0 failures
- [x] `bundle exec rspec` — 617 examples, 0 failures

Tests cover:
- The +1/+1 buff and hexproof are applied to the targeted creature
- The keyword grant is marked `until_eot?`
- Both the P/T boost and hexproof wear off after end of turn

Co-Authored-By: Claude Opus 4.7 (1M context) <noreply@anthropic.com>