### PR TITLE
Add Hunter's Edge

### DIFF
--- a/lib/magic/cards/hunters_edge.rb
+++ b/lib/magic/cards/hunters_edge.rb
@@ -1,0 +1,35 @@
+module Magic
+  module Cards
+    HuntersEdge = Sorcery("Hunter's Edge") do
+      cost generic: 3, green: 1
+
+      def multi_target? = true
+
+      def target_choices
+        [
+          battlefield.creatures.controlled_by(controller),
+          battlefield.creatures.not_controlled_by(controller),
+        ]
+      end
+
+      def resolve!(targets:)
+        first_creature, second_creature = targets
+
+        trigger_effect(
+          :add_counter,
+          target: first_creature,
+          counter_type: "+1/+1",
+        )
+
+        game.tick!
+
+        trigger_effect(
+          :deal_damage,
+          source: first_creature,
+          target: second_creature,
+          damage: first_creature.power,
+        )
+      end
+    end
+  end
+end

--- a/spec/cards/hunters_edge_spec.rb
+++ b/spec/cards/hunters_edge_spec.rb
@@ -1,0 +1,35 @@
+# frozen_string_literal: true
+
+require 'spec_helper'
+
+RSpec.describe Magic::Cards::HuntersEdge do
+  include_context "two player game"
+
+  let!(:wood_elves) { ResolvePermanent("Wood Elves", owner: p1) }
+  let!(:alpine_watchdog) { ResolvePermanent("Alpine Watchdog", owner: p2) }
+
+  let(:hunters_edge) { Card("Hunter's Edge") }
+
+  it "puts a +1/+1 counter on your creature, then it deals damage equal to its new power to opponent's creature" do
+    p1.add_mana(green: 4)
+    p1.cast(card: hunters_edge) do
+      _1.targeting(wood_elves, alpine_watchdog)
+      _1.pay_mana(green: 1, generic: { green: 3 })
+    end
+    game.stack.resolve!
+    game.tick!
+
+    expect(wood_elves.power).to eq(2)
+    expect(wood_elves.toughness).to eq(2)
+    expect(alpine_watchdog.damage).to eq(2)
+  end
+
+  it "only allows targeting your creature first and an opponent's creature second" do
+    p1.hand.add(hunters_edge)
+    cast = p1.prepare_cast(card: hunters_edge)
+    expect(cast.target_choices[0]).to include(wood_elves)
+    expect(cast.target_choices[0]).not_to include(alpine_watchdog)
+    expect(cast.target_choices[1]).to include(alpine_watchdog)
+    expect(cast.target_choices[1]).not_to include(wood_elves)
+  end
+end


### PR DESCRIPTION
## Summary
- Implements Hunter's Edge (Core Set 2021): sorcery, {3}{G}, puts a +1/+1 counter on a creature you control, then that creature deals damage equal to its (post-counter) power to a creature you don't control.
- Two-target spell using the `multi_target?` / `target_choices` pattern (mirrors Primal Might), restricting target 1 to your creatures and target 2 to opponent's creatures.
- Counter is added and `game.tick!` runs before damage so power reflects the new counter; uses `:deal_damage` (one-way, not `fight`) so the targeted creature doesn't strike back.

## Test plan
- [x] `bundle exec rspec spec/cards/hunters_edge_spec.rb` (2 examples, 0 failures)
- [x] `bundle exec rspec` full suite (617 examples, 0 failures)

Closes #199

🤖 Generated with [Claude Code](https://claude.com/claude-code)