### PR TITLE
Add Return to Nature

### DIFF
--- a/lib/magic/cards/return_to_nature.rb
+++ b/lib/magic/cards/return_to_nature.rb
@@ -1,0 +1,43 @@
+module Magic
+  module Cards
+    ReturnToNature = Instant("Return to Nature") do
+      cost green: 1
+    end
+
+    class ReturnToNature < Instant
+      class DestroyTargetArtifact < Mode
+        def target_choices
+          game.battlefield.permanents.by_any_type("Artifact")
+        end
+
+        def resolve!(target:)
+          trigger_effect(:destroy_target, target: target)
+        end
+      end
+
+      class DestroyTargetEnchantment < Mode
+        def target_choices
+          game.battlefield.permanents.by_any_type("Enchantment")
+        end
+
+        def resolve!(target:)
+          trigger_effect(:destroy_target, target: target)
+        end
+      end
+
+      class ExileTargetCardFromGraveyard < Mode
+        def target_choices
+          game.graveyard_cards
+        end
+
+        def resolve!(target:)
+          trigger_effect(:exile, source: source, target: target)
+        end
+      end
+
+      modes DestroyTargetArtifact,
+        DestroyTargetEnchantment,
+        ExileTargetCardFromGraveyard
+    end
+  end
+end

--- a/spec/cards/return_to_nature_spec.rb
+++ b/spec/cards/return_to_nature_spec.rb
@@ -1,0 +1,66 @@
+# frozen_string_literal: true
+require "spec_helper"
+
+RSpec.describe Magic::Cards::ReturnToNature do
+  include_context "two player game"
+
+  let(:return_to_nature) { Card("Return To Nature") }
+
+  it "destroys target artifact" do
+    great_furnace = ResolvePermanent("Great Furnace", owner: p2)
+
+    mode_class = return_to_nature.modes[0]
+
+    p1.add_mana(green: 1)
+    p1.cast(card: return_to_nature) do
+      _1.choose_mode(mode_class) do |mode|
+        mode.targeting(great_furnace)
+      end
+      _1.auto_pay_mana
+    end
+
+    game.stack.resolve!
+
+    expect(great_furnace.zone).to be_nil
+    expect(great_furnace.card.zone).to be_graveyard
+  end
+
+  it "destroys target enchantment" do
+    griffin_aerie = ResolvePermanent("Griffin Aerie", owner: p2)
+
+    mode_class = return_to_nature.modes[1]
+
+    p1.add_mana(green: 1)
+    p1.cast(card: return_to_nature) do
+      _1.choose_mode(mode_class) do |mode|
+        mode.targeting(griffin_aerie)
+      end
+      _1.auto_pay_mana
+    end
+
+    game.stack.resolve!
+
+    expect(griffin_aerie.zone).to be_nil
+    expect(griffin_aerie.card.zone).to be_graveyard
+  end
+
+  it "exiles target card from a graveyard" do
+    wood_elves = Card("Wood Elves", owner: p2)
+    wood_elves.move_to_graveyard!
+
+    mode_class = return_to_nature.modes[2]
+
+    p1.add_mana(green: 1)
+    p1.cast(card: return_to_nature) do
+      _1.choose_mode(mode_class) do |mode|
+        mode.targeting(wood_elves)
+      end
+      _1.auto_pay_mana
+    end
+
+    game.stack.resolve!
+
+    expect(wood_elves.zone).to be_exile
+    expect(p2.graveyard).not_to include(wood_elves)
+  end
+end


### PR DESCRIPTION
## Summary
- Implements "Return to Nature" (Core Set 2021) — Instant, {G}.
- Three modal effects: destroy target artifact, destroy target enchantment, or exile target card from a graveyard.
- Uses the `Mode` DSL pattern (matching `SublimeEpiphany` / `ReadTheTides`).

Closes #210

## Test plan
- [x] `bundle exec rspec spec/cards/return_to_nature_spec.rb` passes (3 examples).
- [x] `bundle exec rspec` (full suite) passes (618 examples, 0 failures).

Generated with [Claude Code](https://claude.com/claude-code)