### PR TITLE
Add Invigorating Surge

### DIFF
--- a/lib/magic/cards/invigorating_surge.rb
+++ b/lib/magic/cards/invigorating_surge.rb
@@ -1,0 +1,23 @@
+module Magic
+  module Cards
+    InvigoratingSurge = Instant("Invigorating Surge") do
+      cost generic: 1, green: 1
+    end
+
+    class InvigoratingSurge < Instant
+      def single_target?
+        true
+      end
+
+      def target_choices
+        controller.creatures
+      end
+
+      def resolve!(target:)
+        trigger_effect(:add_counter, counter_type: "+1/+1", target: target)
+        existing = target.counters.of_type(Magic::Counters::Plus1Plus1).count
+        trigger_effect(:add_counter, counter_type: "+1/+1", target: target, amount: existing)
+      end
+    end
+  end
+end

--- a/spec/cards/invigorating_surge_spec.rb
+++ b/spec/cards/invigorating_surge_spec.rb
@@ -1,0 +1,42 @@
+# frozen_string_literal: true
+require "spec_helper"
+
+RSpec.describe Magic::Cards::InvigoratingSurge do
+  include_context "two player game"
+
+  let(:card) { Card("Invigorating Surge") }
+
+  context "targeting a creature with no +1/+1 counters" do
+    let!(:wood_elves) { ResolvePermanent("Wood Elves", owner: p1) }
+
+    it "puts one +1/+1 counter, then doubles to two" do
+      cast_and_resolve(card: card, player: p1, targeting: wood_elves)
+
+      expect(wood_elves.counters.of_type(Magic::Counters::Plus1Plus1).count).to eq(2)
+    end
+  end
+
+  context "targeting a creature with two +1/+1 counters" do
+    let!(:wood_elves) { ResolvePermanent("Wood Elves", owner: p1) }
+
+    before do
+      wood_elves.add_counter("+1/+1", amount: 2)
+    end
+
+    it "adds one to make three, then doubles to six" do
+      cast_and_resolve(card: card, player: p1, targeting: wood_elves)
+
+      expect(wood_elves.counters.of_type(Magic::Counters::Plus1Plus1).count).to eq(6)
+    end
+  end
+
+  context "target choices" do
+    let!(:my_wood_elves) { ResolvePermanent("Wood Elves", owner: p1) }
+    let!(:opponents_wood_elves) { ResolvePermanent("Wood Elves", owner: p2) }
+
+    it "only targets creatures controlled by the caster" do
+      expect(card.target_choices).to include(my_wood_elves)
+      expect(card.target_choices).not_to include(opponents_wood_elves)
+    end
+  end
+end


### PR DESCRIPTION
## Summary
- Implements Invigorating Surge (Core Set 2021): instant, {1}{G}, "Put a +1/+1 counter on target creature you control, then double the number of +1/+1 counters on that creature."
- Targets only creatures controlled by the caster.
- Resolution adds one +1/+1 counter, then adds counters equal to the current count to double the total.

## Test plan
- [x] Targeting a creature with no counters results in 2 counters (1 added, doubled)
- [x] Targeting a creature with 2 counters results in 6 counters (3 then doubled)
- [x] Card only targets creatures controlled by the caster
- [x] Full RSpec suite passes

Closes #200

Generated with [Claude Code](https://claude.com/claude-code)