### PR TITLE
Add Portcullis Vine

### DIFF
--- a/lib/magic/cards/portcullis_vine.rb
+++ b/lib/magic/cards/portcullis_vine.rb
@@ -1,0 +1,23 @@
+module Magic
+  module Cards
+    PortcullisVine = Creature("Portcullis Vine") do
+      cost green: 1
+      power 0
+      toughness 3
+      creature_type "Plant Wall"
+      keywords :defender
+    end
+
+    class PortcullisVine < Creature
+      class DrawCardAbility < Magic::ActivatedAbility
+        costs "{2}, {T}, Sacrifice a creature with defender"
+
+        def resolve!
+          source.controller.draw!
+        end
+      end
+
+      def activated_abilities = [DrawCardAbility]
+    end
+  end
+end

--- a/lib/magic/costs/parser.rb
+++ b/lib/magic/costs/parser.rb
@@ -19,6 +19,8 @@ module Magic
             Mana.new(Costs::Parsers::Mana.parse(cost))
           when "{T}"
             SelfTap.new(source)
+          when /Sacrifice a creature with defender/
+            Sacrifice.new(source, source.controller.creatures.select(&:defender?))
           when /Sacrifice a creature/
             # TODO: Make this target only creatures controlled by player
             Sacrifice.new(source, source.controller.creatures)

--- a/spec/cards/portcullis_vine_spec.rb
+++ b/spec/cards/portcullis_vine_spec.rb
@@ -1,0 +1,69 @@
+# frozen_string_literal: true
+require "spec_helper"
+
+RSpec.describe Magic::Cards::PortcullisVine do
+  include_context "two player game"
+
+  subject! { ResolvePermanent("Portcullis Vine", owner: p1) }
+
+  it "has defender" do
+    expect(subject).to have_keyword(Magic::Cards::Keywords::DEFENDER)
+  end
+
+  it "is a 0/3 Plant Wall" do
+    expect(subject.power).to eq(0)
+    expect(subject.toughness).to eq(3)
+    expect(subject.any_type?("Plant")).to be(true)
+    expect(subject.any_type?("Wall")).to be(true)
+  end
+
+  describe "activated ability" do
+    it "draws a card when sacrificing itself" do
+      hand_size = p1.hand.cards.count
+      p1.add_mana(green: 2)
+
+      ability = subject.activated_abilities.first
+      p1.activate_ability(ability: ability) do
+        _1.pay_mana(generic: { green: 2 })
+        _1.pay_sacrifice(subject)
+      end
+
+      game.stack.resolve!
+      game.tick!
+
+      expect(p1.hand.cards.count).to eq(hand_size + 1)
+      expect(subject.card.zone).to be_graveyard
+    end
+
+    it "draws a card when sacrificing another creature with defender" do
+      other_defender = ResolvePermanent("Warded Battlements", owner: p1)
+      hand_size = p1.hand.cards.count
+      p1.add_mana(green: 2)
+
+      ability = subject.activated_abilities.first
+      p1.activate_ability(ability: ability) do
+        _1.pay_mana(generic: { green: 2 })
+        _1.pay_sacrifice(other_defender)
+      end
+
+      game.stack.resolve!
+      game.tick!
+
+      expect(p1.hand.cards.count).to eq(hand_size + 1)
+      expect(other_defender.card.zone).to be_graveyard
+      expect(subject.tapped?).to be(true)
+    end
+
+    it "lists only creatures with defender as sacrifice choices" do
+      ResolvePermanent("Warded Battlements", owner: p1)
+      ResolvePermanent("Wood Elves", owner: p1)
+
+      ability = subject.activated_abilities.first
+      sacrifice_cost = ability.costs.find { |c| c.is_a?(Magic::Costs::Sacrifice) }
+
+      choice_names = sacrifice_cost.instance_variable_get(:@choices).map(&:name)
+      expect(choice_names).to include("Portcullis Vine", "Warded Battlements")
+      expect(choice_names).not_to include("Wood Elves")
+    end
+  end
+end


### PR DESCRIPTION
## Summary
- Implements Portcullis Vine (Core Set 2021): 0/3 green Plant Wall with defender
- Activated ability: {2}, {T}, Sacrifice a creature with defender: Draw a card
- Extends `Costs::Parser` to recognize "Sacrifice a creature with defender" and filter sacrifice choices accordingly

Closes #205

## Test plan
- [x] `bundle exec rspec spec/cards/portcullis_vine_spec.rb` (5 examples, 0 failures)
- [x] `bundle exec rspec` (620 examples, 0 failures)
- [x] Has defender keyword
- [x] Is a 0/3 Plant Wall
- [x] Draws a card when sacrificing itself
- [x] Draws a card when sacrificing another defender
- [x] Sacrifice choices include only creatures with defender

Generated with [Claude Code](https://claude.com/claude-code)