### PR TITLE
Add Run Afoul

### DIFF
--- a/lib/magic/cards/run_afoul.rb
+++ b/lib/magic/cards/run_afoul.rb
@@ -1,0 +1,44 @@
+module Magic
+  module Cards
+    RunAfoul = Instant("Run Afoul") do
+      cost generic: 1, green: 1
+    end
+
+    class RunAfoul < Instant
+      class Choice < Magic::Choice::Targeted
+        attr_reader :target
+
+        def initialize(actor:, target:)
+          super(actor: actor)
+          @target = target
+        end
+
+        def choices
+          target.creatures.select(&:flying?)
+        end
+
+        def choice_amount
+          1
+        end
+
+        def resolve!(target:)
+          actor.trigger_effect(:sacrifice, target: target)
+        end
+      end
+
+      def single_target?
+        true
+      end
+
+      def target_choices
+        game.opponents(controller)
+      end
+
+      def resolve!(target:)
+        return if target.creatures.none?(&:flying?)
+
+        game.add_choice(Choice.new(actor: self, target: target))
+      end
+    end
+  end
+end

--- a/spec/cards/run_afoul_spec.rb
+++ b/spec/cards/run_afoul_spec.rb
@@ -1,0 +1,55 @@
+# frozen_string_literal: true
+require "spec_helper"
+
+RSpec.describe Magic::Cards::RunAfoul do
+  include_context "two player game"
+
+  subject(:run_afoul) { Card("Run Afoul") }
+
+  context "when the targeted opponent controls a creature with flying" do
+    let!(:concordia_pegasus) { ResolvePermanent("Concordia Pegasus", owner: p2) }
+
+    it "the opponent sacrifices the flying creature" do
+      p1.add_mana(green: 2)
+      p1.cast(card: run_afoul) do |action|
+        action.targeting(p2)
+        action.pay_mana(green: 1, generic: { green: 1 })
+      end
+      game.stack.resolve!
+
+      expect(concordia_pegasus.card.zone).to be_graveyard
+    end
+
+    context "and a non-flying creature" do
+      let!(:wood_elves) { ResolvePermanent("Wood Elves", owner: p2) }
+
+      it "only the flying creature is a valid sacrifice choice" do
+        p1.add_mana(green: 2)
+        p1.cast(card: run_afoul) do |action|
+          action.targeting(p2)
+          action.pay_mana(green: 1, generic: { green: 1 })
+        end
+        game.stack.resolve!
+
+        expect(concordia_pegasus.card.zone).to be_graveyard
+        expect(game.battlefield.creatures).to include(wood_elves)
+      end
+    end
+  end
+
+  context "when the targeted opponent controls no creatures with flying" do
+    let!(:wood_elves) { ResolvePermanent("Wood Elves", owner: p2) }
+
+    it "no choice is created and no creature is sacrificed" do
+      p1.add_mana(green: 2)
+      p1.cast(card: run_afoul) do |action|
+        action.targeting(p2)
+        action.pay_mana(green: 1, generic: { green: 1 })
+      end
+      game.stack.resolve!
+
+      expect(game.battlefield.creatures).to include(wood_elves)
+      expect(game.choices).to be_empty
+    end
+  end
+end


### PR DESCRIPTION
## Summary
- Implements Run Afoul (Core Set 2021): Instant {1}{G} — "Target opponent sacrifices a creature with flying."
- Targets an opponent on cast; on resolution, presents a `Choice::Targeted` over the targeted opponent's flying creatures so they sacrifice one. If the opponent controls no flying creatures, the spell has no effect.

Closes #211

## Test plan
- [x] `bundle exec rspec spec/cards/run_afoul_spec.rb` — 3 examples, 0 failures
- [x] `bundle exec rspec` — full suite green

Generated with Claude Code