### PR TITLE
Add Jolrael, Mwonvuli Recluse

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -194,6 +194,10 @@ before { 2.times { game.next_turn }; go_to_main_phase!; game.stack.resolve!; gam
 
 **`card.creature?` and `card.land?` work on cards in any zone** (not just permanents) — defined in `lib/magic/types.rb` and available on all card objects.
 
+**"Nth event each turn" trigger (e.g. "second card drawn each turn")**: In a `TriggeredAbility#should_perform?`, count matching events from `game.current_turn.events` — events are tracked BEFORE listeners receive them, so the current event is included in the count. Example: `JolraelMwonvuliRecluse::SecondCardDrawTrigger` checks `current_turn.events.select { |e| e.is_a?(Events::CardDraw) && e.player == controller }.count == 2`. Caveat: `game.start!` draws 7 cards into the existing turn 1 event log, so testing fresh-turn triggers requires `2.times { game.next_turn }` to reach a clean turn.
+
+**Setting base power/toughness ("base power and toughness X/X")**: Use `permanent.modify_base_power(n)` and `permanent.modify_base_toughness(n)` (defined in `lib/magic/permanents/modifications.rb`). Adds `Modifications::BasePower` / `BaseToughness` modifiers; `ContinuousEffects` uses the LAST one as the base value (typesetter effect). Modifiers default to `until_eot: true` and are removed in cleanup. To affect all controlled creatures, iterate `controller.creatures.each { _1.modify_base_power(x); _1.modify_base_toughness(x) }`. Example: `JolraelMwonvuliRecluse::ActivatedAbility`.
+
 ## TriggeredAbility Subclasses
 
 Pre-built subclasses in `lib/magic/triggered_ability/` — use these to avoid rewriting `should_perform?`:

--- a/lib/magic/cards/jolrael_mwonvuli_recluse.rb
+++ b/lib/magic/cards/jolrael_mwonvuli_recluse.rb
@@ -1,0 +1,54 @@
+module Magic
+  module Cards
+    JolraelMwonvuliRecluse = Creature("Jolrael, Mwonvuli Recluse") do
+      legendary_creature_type "Human Druid"
+      cost generic: 2, green: 1
+      power 2
+      toughness 3
+    end
+
+    class JolraelMwonvuliRecluse < Creature
+      CatToken = Token.create "Cat" do
+        creature_type "Cat"
+        power 2
+        toughness 2
+        colors :green
+      end
+
+      class SecondCardDrawTrigger < TriggeredAbility
+        def should_perform?
+          return false unless event.player == controller
+
+          card_draws = game.current_turn.events.select do |e|
+            e.is_a?(Events::CardDraw) && e.player == controller
+          end
+          card_draws.count == 2
+        end
+
+        def call
+          actor.trigger_effect(:create_token, token_class: CatToken)
+        end
+      end
+
+      class ActivatedAbility < Magic::ActivatedAbility
+        costs "{4}{G}{G}"
+
+        def resolve!
+          x = controller.hand.count
+          source.controller.creatures.each do |creature|
+            creature.modify_base_power(x)
+            creature.modify_base_toughness(x)
+          end
+        end
+      end
+
+      def event_handlers
+        {
+          Events::CardDraw => SecondCardDrawTrigger
+        }
+      end
+
+      def activated_abilities = [ActivatedAbility]
+    end
+  end
+end

--- a/spec/cards/jolrael_mwonvuli_recluse_spec.rb
+++ b/spec/cards/jolrael_mwonvuli_recluse_spec.rb
@@ -1,0 +1,95 @@
+# frozen_string_literal: true
+
+require "spec_helper"
+
+RSpec.describe Magic::Cards::JolraelMwonvuliRecluse do
+  include_context "two player game"
+
+  subject!(:jolrael) { ResolvePermanent("Jolrael, Mwonvuli Recluse", owner: p1) }
+
+  before do
+    5.times { p1.library.add(Card("Forest")) }
+  end
+
+  context "second card drawn each turn trigger" do
+    before do
+      # Advance back to p1's turn so events are clean.
+      2.times { game.next_turn }
+    end
+
+    it "does not create a token on the first card drawn" do
+      p1.draw!
+      cats = creatures.by_name("Cat")
+      expect(cats.count).to eq(0)
+    end
+
+    it "creates a 2/2 green Cat token on the second card drawn" do
+      p1.draw!
+      p1.draw!
+
+      cats = creatures.by_name("Cat")
+      expect(cats.count).to eq(1)
+      cat = cats.first
+      expect(cat.power).to eq(2)
+      expect(cat.toughness).to eq(2)
+      expect(cat.colors).to eq([:green])
+      expect(cat.controller).to eq(p1)
+    end
+
+    it "does not create a token on the third or later card drawn" do
+      p1.draw!
+      p1.draw!
+      p1.draw!
+
+      cats = creatures.by_name("Cat")
+      expect(cats.count).to eq(1)
+    end
+
+    it "does not trigger on opponent's draws" do
+      p2.draw!
+      p2.draw!
+
+      cats = creatures.by_name("Cat")
+      expect(cats.count).to eq(0)
+    end
+  end
+
+  context "{4}{G}{G} activated ability" do
+    let!(:elf) { ResolvePermanent("Llanowar Elves", owner: p1) }
+
+    it "sets the base power and toughness of creatures you control to the number of cards in your hand" do
+      x = p1.hand.count
+      expect(x).to be > 0
+
+      p1.add_mana(green: 6)
+      p1.activate_ability(ability: jolrael.activated_abilities.first) do
+        _1.pay_mana(green: 2, generic: { green: 4 })
+      end
+
+      game.stack.resolve!
+      game.tick!
+
+      expect(jolrael.power).to eq(x)
+      expect(jolrael.toughness).to eq(x)
+      expect(elf.power).to eq(x)
+      expect(elf.toughness).to eq(x)
+    end
+
+    it "expires at end of turn" do
+      p1.add_mana(green: 6)
+      p1.activate_ability(ability: jolrael.activated_abilities.first) do
+        _1.pay_mana(green: 2, generic: { green: 4 })
+      end
+
+      game.stack.resolve!
+      game.tick!
+
+      game.current_turn.end!
+      game.current_turn.cleanup!
+      game.tick!
+
+      expect(jolrael.power).to eq(2)
+      expect(jolrael.toughness).to eq(3)
+    end
+  end
+end


### PR DESCRIPTION
## Summary
- Implements Jolrael, Mwonvuli Recluse (Core Set 2021): a 2/3 Legendary Creature - Human Druid for {2}{G}.
- Whenever you draw your second card each turn, creates a 2/2 green Cat creature token.
- {4}{G}{G}: Until end of turn, creatures you control have base power and toughness X/X, where X is the number of cards in your hand.

Closes #201

## Test plan
- [x] `bundle exec rspec spec/cards/jolrael_mwonvuli_recluse_spec.rb` passes (6 examples)
- [x] `bundle exec rspec` full suite passes (621 examples, 0 failures)
- Tests cover: no token on first draw; 2/2 green Cat created on second draw; no token on subsequent draws; opponent draws don't trigger; activated ability sets all controlled creatures' base P/T to hand size; effect expires at end of turn.

## Notes
- Used existing `Modifications::BasePower` / `BaseToughness` mechanism via `permanent.modify_base_power(n)` (already used by Riddleform). `ContinuousEffects` picks up the last `BasePower` modifier as the typesetter base, so iterating over `controller.creatures` and applying the modifier produces the desired "base P/T = X" effect that overrides the printed values.
- "Second card drawn each turn" detection uses `game.current_turn.events` — events are tracked before listeners receive them, so the count includes the current event.
- Two new patterns documented in CLAUDE.md.

🤖 Generated with [Claude Code](https://claude.com/claude-code)